### PR TITLE
Fix exceptions in events

### DIFF
--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -270,7 +270,7 @@ namespace LiveKit
                     break;
                 case RoomEvent.MessageOneofCase.TrackUnsubscribed:
                     {
-                        var participant = RemoteParticipants[e.TrackSubscribed.ParticipantSid];
+                        var participant = RemoteParticipants[e.TrackUnsubscribed.ParticipantSid];
                         var publication = participant.Tracks[e.TrackUnsubscribed.TrackSid];
                         var track = publication.Track;
                         publication.UpdateTrack(null);

--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -219,8 +219,8 @@ namespace LiveKit
                 case RoomEvent.MessageOneofCase.ParticipantDisconnected:
                     {
                         var sid = e.ParticipantDisconnected.ParticipantSid;
-                        var participant = RemoteParticipants[Sid];
-                        _participants.Remove(Sid);
+                        var participant = RemoteParticipants[sid];
+                        _participants.Remove(sid);
                         ParticipantDisconnected?.Invoke(participant);
                     }
                     break;


### PR DESCRIPTION
1. Since the room's Sid was used and a `KeyNotFoundException` occurred in the `ParticipantDisconnected` event, so I fixed it to use the Participant's Sid.
1. Since TrackSubscribed was used and a `NullReferenceException` occurred in the `TrackUnsubscribed` event, so I fixed it to use `TrackUnsubscribed`.