### PR TITLE
Fixes bugs with metadata and rpc

### DIFF
--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -30,7 +30,7 @@ namespace LiveKit
         public readonly WeakReference<Room> Room;
         public IReadOnlyDictionary<string, TrackPublication> Tracks => _tracks;
 
-        private Dictionary<string, RpcHandler> _rpcHandlers = new();
+        protected Dictionary<string, RpcHandler> _rpcHandlers = new();
 
         protected Participant(OwnedParticipant participant, Room room)
         {

--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -216,8 +216,8 @@ namespace LiveKit
                         var participant = GetParticipant(e.ParticipantMetadataChanged.ParticipantIdentity);
                         if (participant != null)
                         {
-                            ParticipantMetadataChanged?.Invoke(participant);
                             participant.SetMeta(e.ParticipantMetadataChanged.Metadata);
+                            ParticipantMetadataChanged?.Invoke(participant);
                         }
                         else Utils.Debug("Unable to find participant: " + e.ParticipantMetadataChanged.ParticipantIdentity + " in Meta data Change Event");
                     }


### PR DESCRIPTION
I found two issues when testing this in a unity project
1. _rpcHandlers needs to be protected because it is used in a class that inherits Participant
2. We need to set metadata on the participant before invoking metadataChanged otherwise we do not get the updated metadata in the callback.