### PR TITLE
Add mute request case to prevent exception

### DIFF
--- a/Runtime/Scripts/Internal/FFIClients/FfiRequestExtensions.cs
+++ b/Runtime/Scripts/Internal/FFIClients/FfiRequestExtensions.cs
@@ -81,6 +81,9 @@ namespace LiveKit.Internal.FFIClients
                 case RemixAndResampleRequest remixAndResampleRequest:
                     ffiRequest.RemixAndResample = remixAndResampleRequest;
                     break;
+                case LocalTrackMuteRequest localTrackMuteRequest:
+                    ffiRequest.LocalTrackMute = localTrackMuteRequest;
+                    break;
                 case E2eeRequest e2EeRequest:
                     ffiRequest.E2Ee = e2EeRequest;
                     break;


### PR DESCRIPTION
Allow local mute / unmute local tracks. With this change tracks are effectively muted and no more audio/video data is sent to other participants in a room, however the change is not somehow propagated to the other participants in the room, ie: subscribing to a room's TrackMuted / TrackUnmuted never fires for a Unity client with this PR.

Fixes #67 