### PR TITLE
Expose Participant.Attributes as a public field

### DIFF
--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Collections;
+using Google.Protobuf.Collections;
 using LiveKit.Internal;
 using LiveKit.Proto;
 using LiveKit.Internal.FFIClients.Requests;
@@ -23,6 +23,7 @@ namespace LiveKit
         public string Identity => _info.Identity;
         public string Name => _info.Name;
         public string Metadata => _info.Metadata;
+        public MapField<string, string> Attributes => _info.Attributes;
         public ConnectionQuality ConnectionQuality { internal set; get; }
         public event PublishDelegate TrackPublished;
         public event PublishDelegate TrackUnpublished;


### PR DESCRIPTION
Access participant attributes like so:

```
foreach (var participantAttribute in participant.Attributes)
{
    if (participantAttribute.Key == "YourKeyLabel")
}
```

I'm unsure how proper it is to expose this as-is Google.Protobuf.Collections.MapField<string, string>


Fixes #69 