### PR TITLE
Expose LocalVideoTrack.source as a public field

### DIFF
--- a/Runtime/Scripts/Track.cs
+++ b/Runtime/Scripts/Track.cs
@@ -126,12 +126,12 @@ namespace LiveKit
 
     public sealed class LocalVideoTrack : Track, ILocalTrack, IVideoTrack
     {
-        RtcVideoSource _source;
+        public RtcVideoSource source;
 
-        IRtcSource ILocalTrack.source { get => _source; }
+        IRtcSource ILocalTrack.source => source;
 
         internal LocalVideoTrack(OwnedTrack track, Room room, RtcVideoSource source) : base(track, room, room?.LocalParticipant) {
-            _source = source;
+            this.source = source;
         }
 
         public static LocalVideoTrack CreateVideoTrack(string name, RtcVideoSource source, Room room)


### PR DESCRIPTION
Expose the  LocalVideoTrack.source field as public. For example one could determine the concrete class like so:

``` c#
switch (localTrack.source)
{
    case CameraVideoSource cameraVideoSource:
        break;
    case ScreenVideoSource screenVideoSource:
        break;
    case TextureVideoSource textureVideoSource:
        break;
    case WebCameraSource webCameraSource:
        break;
}
```


Fixes #71 