### PR TITLE
Add GetSessionStatsReceived functionality

### DIFF
--- a/Runtime/Scripts/Internal/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFIClient.cs
@@ -35,6 +35,7 @@ namespace LiveKit.Internal
         public event UnpublishTrackDelegate? UnpublishTrackReceived;
         public event ConnectReceivedDelegate? ConnectReceived;
         public event DisconnectReceivedDelegate? DisconnectReceived;
+        public event GetSessionStatsDelegate? GetSessionStatsReceived;
         public event RoomEventReceivedDelegate? RoomEventReceived;
         public event TrackEventReceivedDelegate? TrackEventReceived;
         public event RpcMethodInvocationReceivedDelegate? RpcMethodInvocationReceived;
@@ -248,6 +249,9 @@ namespace LiveKit.Internal
                     case FfiEvent.MessageOneofCase.Disconnect:
                         Instance.DisconnectReceived?.Invoke(r.Disconnect!);
                         break;
+                    case FfiEvent.MessageOneofCase.GetStats:
+                        Instance.GetSessionStatsReceived?.Invoke(r.GetStats);
+                        break;
                     case FfiEvent.MessageOneofCase.PublishTranscription:
                         break;
                     case FfiEvent.MessageOneofCase.VideoStreamEvent:
@@ -261,7 +265,6 @@ namespace LiveKit.Internal
                     case FfiEvent.MessageOneofCase.PerformRpc:
                         Instance.PerformRpcReceived?.Invoke(r.PerformRpc!);
                         break;
-                    case FfiEvent.MessageOneofCase.GetStats:
                     case FfiEvent.MessageOneofCase.Panic:
                         break;
                     default:

--- a/Runtime/Scripts/Internal/FFIClients/FFIEvents.cs
+++ b/Runtime/Scripts/Internal/FFIClients/FFIEvents.cs
@@ -20,7 +20,8 @@ namespace LiveKit.Internal
 
     internal delegate void DisconnectReceivedDelegate(DisconnectCallback e);
 
-
+    internal delegate void GetSessionStatsDelegate(GetStatsCallback e);
+    
     // Events
     internal delegate void RoomEventReceivedDelegate(RoomEvent e);
 


### PR DESCRIPTION
This PR aims at exposing webrtc statistics. For example one could gather from a List<ITrack> statistics every 1 second:


```c#
private readonly List<ITrack> _tracksToCollect = new();

private IEnumerator GetStatsEverySecond()
{
    while (true)
    {
        yield return new WaitForSeconds(1);
        var stats = new List<RtcStats>();
        foreach (var track in _tracksToCollect)
        {
            var latestStats = track.GetStats();
            yield return latestStats;
            if (latestStats.IsError)
            {
                Debug.LogError(latestStats.Error);
                continue;
            }

            foreach (var stat in stats)
            {
                switch (stat.StatsCase)
                {
                    case RtcStats.StatsOneofCase.OutboundRtp:
                    case RtcStats.StatsOneofCase.InboundRtp:
                    case RtcStats.StatsOneofCase.RemoteInboundRtp:
                    case RtcStats.StatsOneofCase.RemoteOutboundRtp:
                    case RtcStats.StatsOneofCase.None:
                    case RtcStats.StatsOneofCase.Codec:
                    case RtcStats.StatsOneofCase.MediaSource:
                    case RtcStats.StatsOneofCase.MediaPlayout:
                    case RtcStats.StatsOneofCase.PeerConnection:
                    case RtcStats.StatsOneofCase.DataChannel:
                    case RtcStats.StatsOneofCase.Transport:
                    case RtcStats.StatsOneofCase.CandidatePair:
                    case RtcStats.StatsOneofCase.LocalCandidate:
                    case RtcStats.StatsOneofCase.RemoteCandidate:
                    case RtcStats.StatsOneofCase.Certificate:
                    case RtcStats.StatsOneofCase.Track:
                        break;
                }
            }
        }
    }
}
```
        
Fixes #73