### PR TITLE
Increase video timestamping precision from milli to micro

### DIFF
--- a/Runtime/Scripts/RtcVideoSource.cs
+++ b/Runtime/Scripts/RtcVideoSource.cs
@@ -188,7 +188,8 @@ namespace LiveKit
                 var capture = request.request;
                 capture.SourceHandle = (ulong)Handle.DangerousGetHandle();
                 capture.Rotation = GetVideoRotation();
-                capture.TimestampUs = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+                var now = DateTimeOffset.UtcNow;
+                capture.TimestampUs = now.ToUnixTimeMilliseconds() * 1000 + (now.Ticks % TimeSpan.TicksPerMillisecond) / 10;
                 capture.Buffer = buffer;
                 using var response = request.Send();
                 _reading = false;


### PR DESCRIPTION
This PR increases the timestamp precision which is in turn used to determine whether or not to send frames down the stack.

I have confirmed this reaches playing back at the source's target framerate by printing out the number of frames received in a ...

I see that in the native library, there's logic to [assign a timestamp directly in rust](https://github.com/livekit/rust-sdks/blob/cc889daa26c2ea50258932708a24e095dcc850cc/libwebrtc/src/native/video_source.rs#L102-L108), so I tried setting the C# TimestampUs field to 0, and confirmed the results are the same as the playback rate matches the source.

Fixes #75 