### PR TITLE
Dynamically set video rotation

### DIFF
--- a/Runtime/Scripts/WebCameraSource.cs
+++ b/Runtime/Scripts/WebCameraSource.cs
@@ -28,6 +28,11 @@ namespace LiveKit
 
         protected override VideoRotation GetVideoRotation()
         {
+            switch (Texture.videoRotationAngle)
+            {
+                case 90: return VideoRotation._90;
+                case 180: return VideoRotation._0;
+            }
             return VideoRotation._180;
         }
 


### PR DESCRIPTION
Fixes an issue on iOS where published `WebCameraSource` is improperly oriented when viewed by a remote participant.

CLT-1416