### PR TITLE
Enhance Disconnect Event

### DIFF
--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -125,6 +125,7 @@ namespace LiveKit
         public delegate void SipDtmfDelegate(Participant participant, UInt32 code, string digit);
         public delegate void ConnectionStateChangeDelegate(ConnectionState connectionState);
         public delegate void ConnectionDelegate(Room room);
+        public delegate void DisconnectDelegate(DisconnectReason reason);
         public delegate void E2EeStateChangedDelegate(Participant participant, EncryptionState state);
 
         public string Sid { private set; get; }
@@ -152,7 +153,7 @@ namespace LiveKit
         public event SipDtmfDelegate SipDtmfReceived;
         public event ConnectionStateChangeDelegate ConnectionStateChanged;
         public event ConnectionDelegate Connected;
-        public event ConnectionDelegate Disconnected;
+        public event DisconnectDelegate Disconnected;
         public event ConnectionDelegate Reconnecting;
         public event ConnectionDelegate Reconnected;
         public event E2EeStateChangedDelegate E2EeStateChanged;
@@ -455,7 +456,7 @@ namespace LiveKit
                     ConnectionStateChanged?.Invoke(e.ConnectionStateChanged.State);
                     break;
                 case RoomEvent.MessageOneofCase.Disconnected:
-                    Disconnected?.Invoke(this);
+                    Disconnected?.Invoke(e.Disconnected.Reason);
                     OnDisconnect();
                     break;
                 case RoomEvent.MessageOneofCase.Reconnecting:
@@ -493,6 +494,8 @@ namespace LiveKit
 
         private void OnDisconnectReceived(DisconnectCallback e)
         {
+            OnDisconnect();
+            Disconnected?.Invoke(DisconnectReason.ClientInitiated);
             FfiClient.Instance.DisconnectReceived -= OnDisconnectReceived;
             Utils.Debug($"OnDisconnect.... {e}");
         }


### PR DESCRIPTION
Enhance Disconnect Event with Reason Information

This PR updates the `Disconnected` event to include a `DisconnectReason`, providing more context when disconnections occur. It ensures that disconnect events fire consistently across all disconnection paths, including the `DisconnectReceived` callback, and not just via the room events.

- Introduced `DisconnectDelegate` to handle disconnection events with a reason
- Updated the `Disconnected` event to use `DisconnectDelegate`
- Ensured `Disconnected` event fires with the appropriate reason when disconnection occurs via `DisconnectReceived`

Fixes #101 