### PR TITLE
Fix video source memory handling

### DIFF
--- a/Runtime/Scripts/CameraVideoSource.cs
+++ b/Runtime/Scripts/CameraVideoSource.cs
@@ -41,7 +41,7 @@ namespace LiveKit
 
         ~CameraVideoSource()
         {
-            Dispose();
+            Dispose(false);
             ClearRenderTexture();
         }
 

--- a/Runtime/Scripts/CameraVideoSource.cs
+++ b/Runtime/Scripts/CameraVideoSource.cs
@@ -94,7 +94,7 @@ namespace LiveKit
                 }
                 _previewTexture.SetPixels(flippedPixels);
 #else
-                Graphics.CopyTexture(_renderTexture, _dest);
+                Graphics.CopyTexture(_renderTexture, _captureBuffer);
 #endif
 
                 AsyncGPUReadback.RequestIntoNativeArray(ref _captureBuffer, _renderTexture, 0, _textureFormat, OnReadback);

--- a/Runtime/Scripts/CameraVideoSource.cs
+++ b/Runtime/Scripts/CameraVideoSource.cs
@@ -77,27 +77,27 @@ namespace LiveKit
                     _bufferType = GetVideoBufferType(_textureFormat);
                     _renderTexture = new RenderTexture(GetWidth(), GetHeight(), 0, compatibleFormat);
                     Camera.targetTexture = _renderTexture as RenderTexture;
-                    _data = new NativeArray<byte>(GetWidth() * GetHeight() * GetStrideForBuffer(_bufferType), Allocator.Persistent);
-                    _dest = new Texture2D(GetWidth(), GetHeight(), _textureFormat, false);
+                    _captureBuffer = new NativeArray<byte>(GetWidth() * GetHeight() * GetStrideForBuffer(_bufferType), Allocator.Persistent);
+                    _previewTexture = new Texture2D(GetWidth(), GetHeight(), _textureFormat, false);
                     textureChanged = true;
                 }
                 ScreenCapture.CaptureScreenshotIntoRenderTexture(_renderTexture);
 
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
                 // Flip the texture for OSX
-                Graphics.CopyTexture(_renderTexture, _dest);
-                var pixels = _dest.GetPixels();
+                Graphics.CopyTexture(_renderTexture, _previewTexture);
+                var pixels = _previewTexture.GetPixels();
                 var flippedPixels = new Color[pixels.Length];
-                for (int i = 0; i < _dest.height; i++)
+                for (int i = 0; i < _previewTexture.height; i++)
                 {
-                    Array.Copy(pixels, i * _dest.width, flippedPixels, (_dest.height - i - 1) * _dest.width, _dest.width);
+                    Array.Copy(pixels, i * _previewTexture.width, flippedPixels, (_previewTexture.height - i - 1) * _previewTexture.width, _previewTexture.width);
                 }
-                _dest.SetPixels(flippedPixels);
+                _previewTexture.SetPixels(flippedPixels);
 #else
                 Graphics.CopyTexture(_renderTexture, _dest);
 #endif
 
-                AsyncGPUReadback.RequestIntoNativeArray(ref _data, _renderTexture, 0, _textureFormat, OnReadback);
+                AsyncGPUReadback.RequestIntoNativeArray(ref _captureBuffer, _renderTexture, 0, _textureFormat, OnReadback);
             }
             catch (Exception e)
             {

--- a/Runtime/Scripts/CameraVideoSource.cs
+++ b/Runtime/Scripts/CameraVideoSource.cs
@@ -94,7 +94,7 @@ namespace LiveKit
                 }
                 _previewTexture.SetPixels(flippedPixels);
 #else
-                Graphics.CopyTexture(_renderTexture, _captureBuffer);
+                Graphics.CopyTexture(_renderTexture, _previewTexture);
 #endif
 
                 AsyncGPUReadback.RequestIntoNativeArray(ref _captureBuffer, _renderTexture, 0, _textureFormat, OnReadback);

--- a/Runtime/Scripts/ScreenVideoSource.cs
+++ b/Runtime/Scripts/ScreenVideoSource.cs
@@ -41,7 +41,7 @@ namespace LiveKit
 
         ~ScreenVideoSource()
         {
-            Dispose();
+            Dispose(false);
             ClearRenderTexture();
         }
 

--- a/Runtime/Scripts/ScreenVideoSource.cs
+++ b/Runtime/Scripts/ScreenVideoSource.cs
@@ -70,27 +70,27 @@ namespace LiveKit
                     _textureFormat = GraphicsFormatUtility.GetTextureFormat(compatibleFormat);
                     _bufferType = GetVideoBufferType(_textureFormat);
                     _renderTexture = new RenderTexture(GetWidth(), GetHeight(), 0, compatibleFormat);
-                    _data = new NativeArray<byte>(GetWidth() * GetHeight() * GetStrideForBuffer(_bufferType), Allocator.Persistent);
-                    _dest = new Texture2D(GetWidth(), GetHeight(), _textureFormat, false);
+                    _captureBuffer = new NativeArray<byte>(GetWidth() * GetHeight() * GetStrideForBuffer(_bufferType), Allocator.Persistent);
+                    _previewTexture = new Texture2D(GetWidth(), GetHeight(), _textureFormat, false);
                     textureChanged = true;
                 }
                 ScreenCapture.CaptureScreenshotIntoRenderTexture(_renderTexture);
 
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
                 // Flip the texture for OSX
-                Graphics.CopyTexture(_renderTexture, _dest);
-                var pixels = _dest.GetPixels();
+                Graphics.CopyTexture(_renderTexture, _previewTexture);
+                var pixels = _previewTexture.GetPixels();
                 var flippedPixels = new Color[pixels.Length];
-                for (int i = 0; i < _dest.height; i++)
+                for (int i = 0; i < _previewTexture.height; i++)
                 {
-                    Array.Copy(pixels, i * _dest.width, flippedPixels, (_dest.height - i - 1) * _dest.width, _dest.width);
+                    Array.Copy(pixels, i * _previewTexture.width, flippedPixels, (_previewTexture.height - i - 1) * _previewTexture.width, _previewTexture.width);
                 }
-                _dest.SetPixels(flippedPixels);
+                _previewTexture.SetPixels(flippedPixels);
 #else
-                Graphics.CopyTexture(_renderTexture, _dest);
+                Graphics.CopyTexture(_renderTexture, _previewTexture);
 #endif
 
-                AsyncGPUReadback.RequestIntoNativeArray(ref _data, _renderTexture, 0, _textureFormat, OnReadback);
+                AsyncGPUReadback.RequestIntoNativeArray(ref _captureBuffer, _renderTexture, 0, _textureFormat, OnReadback);
             }
             catch (Exception e)
             {

--- a/Runtime/Scripts/TextureVideoSource.cs
+++ b/Runtime/Scripts/TextureVideoSource.cs
@@ -36,7 +36,7 @@ namespace LiveKit
 
         ~TextureVideoSource()
         {
-            Dispose(); 
+            Dispose();
         }
 
         // Read the texture data into a native array asynchronously
@@ -47,16 +47,16 @@ namespace LiveKit
             _reading = true;
             var textureChanged = false;
 
-            if (_dest == null || _dest.width != GetWidth() || _dest.height != GetHeight()) {
+            if (_previewTexture == null || _previewTexture.width != GetWidth() || _previewTexture.height != GetHeight()) {
                 var compatibleFormat = SystemInfo.GetCompatibleFormat(Texture.graphicsFormat, FormatUsage.ReadPixels);
                 _textureFormat = GraphicsFormatUtility.GetTextureFormat(compatibleFormat);
                 _bufferType = GetVideoBufferType(_textureFormat);
-                _data = new NativeArray<byte>(GetWidth() * GetHeight() * GetStrideForBuffer(_bufferType), Allocator.Persistent);
-                _dest = new Texture2D(GetWidth(), GetHeight(), _textureFormat, false);
+                _captureBuffer = new NativeArray<byte>(GetWidth() * GetHeight() * GetStrideForBuffer(_bufferType), Allocator.Persistent);
+                _previewTexture = new Texture2D(GetWidth(), GetHeight(), _textureFormat, false);
                 textureChanged = true;
             }
-            Graphics.CopyTexture(Texture, _dest);
-            AsyncGPUReadback.RequestIntoNativeArray(ref _data, _dest, 0, _textureFormat, OnReadback);
+            Graphics.CopyTexture(Texture, _previewTexture);
+            AsyncGPUReadback.RequestIntoNativeArray(ref _captureBuffer, _previewTexture, 0, _textureFormat, OnReadback);
             return textureChanged;
         }
     }

--- a/Runtime/Scripts/TextureVideoSource.cs
+++ b/Runtime/Scripts/TextureVideoSource.cs
@@ -36,7 +36,7 @@ namespace LiveKit
 
         ~TextureVideoSource()
         {
-            Dispose();
+            Dispose(false);
         }
 
         // Read the texture data into a native array asynchronously

--- a/Runtime/Scripts/WebCameraSource.cs
+++ b/Runtime/Scripts/WebCameraSource.cs
@@ -42,7 +42,7 @@ namespace LiveKit
 
         ~WebCameraSource()
         {
-            Dispose();
+            Dispose(false);
         }
 
         private Color32[] _readBuffer;
@@ -62,6 +62,7 @@ namespace LiveKit
                 _previewTexture.width != width ||
                 _previewTexture.height != height)
             {
+                Debug.Log("Creating new texture");
                 // Required when using Allocator.Persistent
                 if (_captureBuffer.IsCreated)
                     _captureBuffer.Dispose();

--- a/Runtime/Scripts/WebCameraSource.cs
+++ b/Runtime/Scripts/WebCameraSource.cs
@@ -95,7 +95,7 @@ namespace LiveKit
             else
             {
 #if UNITY_6000_0_OR_NEWER && UNITY_IOS
-                _previewTexture.SetPixels(Texture.GetPixels());
+                _previewTexture.SetPixels(CamTexture.GetPixels());
                 _previewTexture.Apply();
 #else
                 Graphics.CopyTexture(CamTexture, _previewTexture);

--- a/Runtime/Scripts/WebCameraSource.cs
+++ b/Runtime/Scripts/WebCameraSource.cs
@@ -1,9 +1,7 @@
 using UnityEngine;
 using LiveKit.Proto;
-using UnityEngine.Rendering;
 using Unity.Collections;
 using UnityEngine.Experimental.Rendering;
-using System;
 using System.Runtime.InteropServices;
 
 namespace LiveKit
@@ -14,21 +12,21 @@ namespace LiveKit
         TextureFormat _textureFormat;
         private RenderTexture _tempTexture;
 
-        public WebCamTexture Texture { get; }
+        public WebCamTexture CamTexture { get; }
 
         public override int GetWidth()
         {
-            return Texture.width;
+            return CamTexture.width;
         }
 
         public override int GetHeight()
         {
-            return Texture.height;
+            return CamTexture.height;
         }
 
         protected override VideoRotation GetVideoRotation()
         {
-            switch (Texture.videoRotationAngle)
+            switch (CamTexture.videoRotationAngle)
             {
                 case 90: return VideoRotation._90;
                 case 180: return VideoRotation._0;
@@ -38,7 +36,7 @@ namespace LiveKit
 
         public WebCameraSource(WebCamTexture texture, VideoBufferType bufferType = VideoBufferType.Rgba) : base(VideoStreamSource.Texture, bufferType)
         {
-            Texture = texture;
+            CamTexture = texture;
             base.Init();
         }
 
@@ -47,43 +45,59 @@ namespace LiveKit
             Dispose();
         }
 
+        private Color32[] _readBuffer;
+
         // Read the texture data into a native array asynchronously
         protected override bool ReadBuffer()
         {
-            if (_reading && !Texture.isPlaying)
+            if (_reading && !CamTexture.isPlaying)
                 return false;
             _reading = true;
             var textureChanged = false;
 
-            if (_dest == null || _dest.width != GetWidth() || _dest.height != GetHeight())
+            int width = GetWidth();
+            int height = GetHeight();
+
+            if (_previewTexture == null ||
+                _previewTexture.width != width ||
+                _previewTexture.height != height)
             {
-                var compatibleFormat = SystemInfo.GetCompatibleFormat(Texture.graphicsFormat, FormatUsage.ReadPixels);
+                // Required when using Allocator.Persistent
+                if (_captureBuffer.IsCreated)
+                    _captureBuffer.Dispose();
+
+                var compatibleFormat = SystemInfo.GetCompatibleFormat(CamTexture.graphicsFormat, FormatUsage.ReadPixels);
                 _textureFormat = GraphicsFormatUtility.GetTextureFormat(compatibleFormat);
                 _bufferType = GetVideoBufferType(_textureFormat);
-                _data = new NativeArray<byte>(GetWidth() * GetHeight() * GetStrideForBuffer(_bufferType), Allocator.Persistent);
-                _dest = new Texture2D(GetWidth(), GetHeight(), TextureFormat.BGRA32, false);
-                if (Texture.graphicsFormat != _dest.graphicsFormat) _tempTexture = new RenderTexture(GetWidth(), GetHeight(), 0, _dest.graphicsFormat);
+
+                _readBuffer = new Color32[width * height];
+                _previewTexture = new Texture2D(width, height, TextureFormat.BGRA32, false);
+                _captureBuffer = new NativeArray<byte>(width * height * GetStrideForBuffer(_bufferType), Allocator.Persistent);
+
+                if (CamTexture.graphicsFormat != _previewTexture.graphicsFormat)
+                    _tempTexture = new RenderTexture(width, height, 0, _previewTexture.graphicsFormat);
+
                 textureChanged = true;
             }
 
-            Color32[] pixels = new Color32[GetWidth() * GetHeight()];
-            Texture.GetPixels32(pixels);
-            var bytes = MemoryMarshal.Cast<Color32, byte>(pixels);
-            _data.CopyFrom(bytes.ToArray());
+            CamTexture.GetPixels32(_readBuffer);
+            MemoryMarshal.Cast<Color32, byte>(_readBuffer)
+                .CopyTo(_captureBuffer.AsSpan());
+
             _requestPending = true;
-            
-            if (Texture.graphicsFormat != _dest.graphicsFormat)
+
+            if (CamTexture.graphicsFormat != _previewTexture.graphicsFormat)
             {
-                Graphics.Blit(Texture, _tempTexture);
-                Graphics.CopyTexture(_tempTexture, _dest);
+                Graphics.Blit(CamTexture, _tempTexture);
+                Graphics.CopyTexture(_tempTexture, _previewTexture);
             }
             else
             {
 #if UNITY_6000_0_OR_NEWER && UNITY_IOS
-                _dest.SetPixels(Texture.GetPixels());
-                _dest.Apply();
+                _previewTexture.SetPixels(Texture.GetPixels());
+                _previewTexture.Apply();
 #else
-                Graphics.CopyTexture(Texture, _dest);
+                Graphics.CopyTexture(CamTexture, _previewTexture);
 #endif
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io.livekit.livekit-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "displayName": "LiveKit SDK",
   "description": "LiveKit",
   "unity": "2021.3",


### PR DESCRIPTION
This PR addresses two memory issues related to video capture, the first of which was identified by the Unity Profiler as a key contributor to broader performance problems:

1. Extraneous allocations in `WebCameraSource`: the read buffer method was performing two unnecessary heap allocations per call, leading to large GC events and severe performance impacts in other parts of the SDK (namely in audio capture):
```cs
// This results in 2 * width * heigh * 32 bytes being allocated on each invocation
Color32[] pixels = new Color32[GetWidth() * GetHeight()]; // first allocation
Texture.GetPixels32(pixels);
var bytes = MemoryMarshal.Cast<Color32, byte>(pixels);
_data.CopyFrom(bytes.ToArray()); // second allocation*
```
*`Span<T>.ToArray` also performs heap allocation as per the [docs](https://learn.microsoft.com/en-us/dotnet/api/system.span-1.toarray?view=net-9.0). 

The solution is to only allocate the temporary buffer once until the configuration is invalidated, and use `MemoryMarshal` and `Span` methods to avoid the additional `ToArray` call:
```cs
CamTexture.GetPixels32(pixels);
MemoryMarshal.Cast<Color32, byte>(pixels)
    .CopyTo(_captureBuffer.AsSpan());
```

2. Native array used by `RtcVideoSource` and its subclasses was not disposed of, causing a memory leak; when a native array is created using `Allocator.Persistent`, a manual call to dispose [is required](https://stackoverflow.com/questions/76623317/whats-the-difference-between-the-allocators-of-a-nativearray). `RtcVideoSource` now implements `IDispose` to ensure the native array is disposed of even if `Dispose()` is not manually called.

CLT-1613