### PR TITLE
clear previous values of PublishDataRequest FFI Request object

### DIFF
--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -332,6 +332,11 @@ namespace LiveKit
 
             var publish = request.request;
             publish.LocalParticipantHandle = (ulong)Handle.DangerousGetHandle();
+
+            // Clear previous values of conditional fields
+            publish.DestinationIdentities.Clear();
+            publish.ClearTopic();
+
             publish.Reliable = reliable;
 
             if (destination_identities is not null)


### PR DESCRIPTION
PublishData FFI request was not getting cleared properly, so the destination identities field was getting incremented with each call. So after a couple thousand messages, the data packet size ends up going over our limit and the SFU stopped sending them. 

This is a temporary fix, I think the entire FFI layer needs to be rewritten to not have to manually clear them like this. 