### PR TITLE
fix the comment and default value for responseTimeout

### DIFF
--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -207,7 +207,9 @@ namespace LiveKit
         /// - DestinationIdentity: The identity of the participant to call
         /// - Method: Name of the method to call (up to 64 bytes UTF-8)
         /// - Payload: String payload (max 15KiB UTF-8)
-        /// - ResponseTimeout: Maximum time to wait for response (defaults to 10 seconds)</param>
+        /// - ResponseTimeout: Maximum time to wait for response (defaults to 15 seconds)
+        ///   If a value less than 8 seconds is provided, it will be automatically clamped to 8 seconds
+        ///   to ensure sufficient time for round-trip latency buffering.</param>
         /// <returns>
         /// A <see cref="PerformRpcInstruction"/> that completes when the RPC call receives a response or errors.
         /// Check <see cref="PerformRpcInstruction.IsError"/> and access <see cref="PerformRpcInstruction.Payload"/>/<see cref="PerformRpcInstruction.Error"/> properties to handle the result.

--- a/Runtime/Scripts/Rpc.cs
+++ b/Runtime/Scripts/Rpc.cs
@@ -26,9 +26,12 @@ namespace LiveKit
         public string Payload { get; set; }
 
         /// <summary>
-        /// The maximum time to wait for a response from the remote participant. Default is 10 seconds.
+        /// Timeout for receiving a response after the initial connection (in seconds).
+        /// If a value less than 8s is provided, it will be automatically clamped to 8s
+        /// to ensure sufficient time for round-trip latency buffering.
+        /// Default is 15 seconds.
         /// </summary>
-        public float ResponseTimeout { get; set; } = 10f;
+        public float ResponseTimeout { get; set; } = 15f;
     }
 
     /// <summary>


### PR DESCRIPTION
This PR fixes the default of RPC ResponseTimeout to 15s, and improved the comment

See similar PR on JS SDK: https://github.com/livekit/client-sdk-js/pull/1694