### PR TITLE
Fix Meta Quest audio capture failures by making sample rate and channels configurable

### DIFF
--- a/Runtime/Scripts/MicrophoneSource.cs
+++ b/Runtime/Scripts/MicrophoneSource.cs
@@ -14,6 +14,7 @@ namespace LiveKit
     {
         private readonly GameObject _sourceObject;
         private readonly string _deviceName;
+        private readonly uint _sampleRate;
 
         public override event Action<float[], int, int> AudioRead;
 
@@ -27,10 +28,14 @@ namespace LiveKit
         /// get the list of available devices.</param>
         /// <param name="sourceObject">The GameObject to attach the AudioSource to. The object must be kept in the scene
         /// for the duration of the source's lifetime.</param>
-        public MicrophoneSource(string deviceName, GameObject sourceObject) : base(2, RtcAudioSourceType.AudioSourceMicrophone)
+        /// <param name="channels">Number of audio channels (default: 2 for stereo). Configurable at runtime.</param>
+        /// <param name="sampleRate">Sample rate in Hz (default: 48000). Configurable at runtime.</param>
+        public MicrophoneSource(string deviceName, GameObject sourceObject, int channels = 2, uint sampleRate = 48000) 
+            : base(channels, RtcAudioSourceType.AudioSourceMicrophone, sampleRate)
         {
             _deviceName = deviceName;
             _sourceObject = sourceObject;
+            _sampleRate = sampleRate;
         }
 
         /// <summary>
@@ -48,7 +53,6 @@ namespace LiveKit
             base.Start();
             if (_started) return;
 
-
             if (!Application.HasUserAuthorization(mode: UserAuthorization.Microphone))
                 throw new InvalidOperationException("Microphone access not authorized");
 
@@ -60,11 +64,11 @@ namespace LiveKit
 
         private IEnumerator StartMicrophone()
         {
-             var clip = Microphone.Start(
+            var clip = Microphone.Start(
                 _deviceName,
                 loop: true,
                 lengthSec: 1,
-                frequency: (int)DefaultMicrophoneSampleRate
+                frequency: (int)_sampleRate  // Uses configurable sample rate instead of hardcoded default
             );
             if (clip == null)
                 throw new InvalidOperationException("Microphone start failed");

--- a/Runtime/Scripts/RtcAudioSource.cs
+++ b/Runtime/Scripts/RtcAudioSource.cs
@@ -60,16 +60,19 @@ namespace LiveKit
         private bool _started = false;
         private bool _disposed = false;
 
-        protected RtcAudioSource(int channels = 2, RtcAudioSourceType audioSourceType = RtcAudioSourceType.AudioSourceCustom)
+        protected RtcAudioSource(int channels = 2, RtcAudioSourceType audioSourceType = RtcAudioSourceType.AudioSourceCustom, uint? sampleRate = null)
         {
             _sourceType = audioSourceType;
+
+            // Use provided sample rate, or fall back to defaults
+            uint actualSampleRate = sampleRate ?? 
+                (_sourceType == RtcAudioSourceType.AudioSourceMicrophone ? DefaultMicrophoneSampleRate : DefaultSampleRate);
 
             using var request = FFIBridge.Instance.NewRequest<NewAudioSourceRequest>();
             var newAudioSource = request.request;
             newAudioSource.Type = AudioSourceType.AudioSourceNative;
             newAudioSource.NumChannels = (uint)channels;
-            newAudioSource.SampleRate = _sourceType == RtcAudioSourceType.AudioSourceMicrophone ?
-                DefaultMicrophoneSampleRate : DefaultSampleRate;
+            newAudioSource.SampleRate = actualSampleRate;
 
             UnityEngine.Debug.Log($"NewAudioSource: {newAudioSource.NumChannels} {newAudioSource.SampleRate}");
 


### PR DESCRIPTION
## Problem
Audio capture on Meta Quest devices fails with:
**LiveKit: Audio capture failed: an RtcError occured: InvalidState - sample_rate and num_channels don't match**

This occurs because the audio source uses hardcoded default sample rates that don't match what the device actually provides.

## Solution
Make `RtcAudioSource` and `MicrophoneSource` accept optional `sampleRate` and `channels` parameters at runtime instead of relying on hardcoded platform defaults. This allows configuration to match device capabilities.

## Changes
- **RtcAudioSource**: Add optional `uint? sampleRate` parameter to constructor with intelligent fallback to platform defaults
- **MicrophoneSource**: Add optional `channels` and `sampleRate` parameters to constructor (defaults: 2 channels, 48000 Hz)
- Both now pass actual sample rate to `Microphone.Start()` instead of `DefaultMicrophoneSampleRate`

## Notes
- Tested only on version 1.2.6