### PR TITLE
fix: harden Room event handling against crashes and native leaks

### DIFF
--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -467,13 +467,17 @@ namespace LiveKit
                     break;
                 case RoomEvent.MessageOneofCase.ByteStreamOpened:
                     var byteReader = new ByteStreamReader(e.ByteStreamOpened.Reader);
-                    _streamHandlers.Dispatch(byteReader, e.ByteStreamOpened.ParticipantIdentity);
-                    // TODO: Immediately dispose unhandled stream reader
+                    if (!_streamHandlers.Dispatch(byteReader, e.ByteStreamOpened.ParticipantIdentity))
+                    {
+                        byteReader.Dispose();
+                    }
                     break;
                 case RoomEvent.MessageOneofCase.TextStreamOpened:
                     var textReader = new TextStreamReader(e.TextStreamOpened.Reader);
-                    _streamHandlers.Dispatch(textReader, e.TextStreamOpened.ParticipantIdentity);
-                    // TODO: Immediately dispose unhandled stream reader
+                    if (!_streamHandlers.Dispatch(textReader, e.TextStreamOpened.ParticipantIdentity))
+                    {
+                        textReader.Dispose();
+                    }
                     break;
                 case RoomEvent.MessageOneofCase.ConnectionStateChanged:
                     ConnectionState = e.ConnectionStateChanged.State;


### PR DESCRIPTION
Fixes two Room.cs safety issues:

1) Prevents crashes when TrackSubscribed arrives before publication state is initialized.
2) Disposes unhandled text/byte stream readers to avoid native resource leaks.

No API changes; behavior is unchanged for valid flows.
