### PR TITLE
Remove discard of "stale" audio messages, catchup logic for AudioBuffer

### DIFF
--- a/Runtime/Scripts/AudioStream.cs
+++ b/Runtime/Scripts/AudioStream.cs
@@ -29,10 +29,6 @@ namespace LiveKit
         private const float BufferSizeSeconds = 0.2f;  // 200ms ring buffer for all platforms
         private const float PrimingThresholdSeconds = 0.03f;  // Wait for 30ms of data before playing
 
-        // Used to discard stale FFI callbacks after returning from background
-        private double _resumeTimestamp = 0;
-        private const double DiscardWindowSeconds = 0.02;  // Discard callbacks for 20ms after resume
-
         /// <summary>
         /// Creates a new audio stream from a remote audio track, attaching it to the
         /// given <see cref="AudioSource"/> in the scene.
@@ -68,7 +64,7 @@ namespace LiveKit
             MonoBehaviourContext.OnApplicationPauseEvent += OnApplicationPause;
         }
 
-        // Called on Unity audio thread
+        // Called on FFI callback thread
         private void OnAudioRead(float[] data, int channels, int sampleRate)
         {
             if (_disposed)
@@ -170,7 +166,6 @@ namespace LiveKit
             {
                 lock (_lock)
                 {
-                    _resumeTimestamp = Time.realtimeSinceStartupAsDouble;
                     if (_buffer != null)
                     {
                         _buffer.Clear();
@@ -197,13 +192,6 @@ namespace LiveKit
 
             lock (_lock)
             {
-                // Discard stale FFI callbacks that arrive shortly after returning from background.
-                // These callbacks may contain audio data buffered while the app was paused.
-                if (_resumeTimestamp > 0 && Time.realtimeSinceStartupAsDouble - _resumeTimestamp < DiscardWindowSeconds)
-                {
-                    return;
-                }
-
                 if (_numChannels == 0)
                     return;
 

--- a/Runtime/Scripts/AudioStream.cs
+++ b/Runtime/Scripts/AudioStream.cs
@@ -64,7 +64,7 @@ namespace LiveKit
             MonoBehaviourContext.OnApplicationPauseEvent += OnApplicationPause;
         }
 
-        // Called on FFI callback thread
+        // Called on Unity audio thread
         private void OnAudioRead(float[] data, int channels, int sampleRate)
         {
             if (_disposed)
@@ -128,9 +128,9 @@ namespace LiveKit
                 int samplesRead = bytesRead / sizeof(short);
 
                 // Underrun detection: If we couldn't read enough samples, immediately output silence
-                // and wait for the buffer to refill to 30ms before resuming playback.
+                // and wait for the buffer to refill enough to offer Unity a full sample.
                 // This prevents choppy audio from playing partial samples during underrun.
-                if (samplesRead < data.Length * 0.5f)  // If we got less than 50% of requested samples
+                if (samplesRead < data.Length)
                 {
                     _isPrimed = false;
                     Utils.Debug($"AudioStream underrun detected, re-priming (got {samplesRead}/{data.Length} samples)");
@@ -176,7 +176,7 @@ namespace LiveKit
             }
         }
 
-        // Called on the MainThread (See FfiClient)
+        // Called on FFI callback thread       
         private void OnAudioStreamEvent(AudioStreamEvent e)
         {
             if (_disposed)

--- a/Runtime/Scripts/AudioStream.cs
+++ b/Runtime/Scripts/AudioStream.cs
@@ -116,6 +116,22 @@ namespace LiveKit
                     }
                 }
 
+                int valuesAvailableToRead = _buffer.AvailableRead() / sizeof(short);
+                // Underrun detection: If we couldn't read enough samples, immediately output silence
+                // and wait for the buffer to refill enough to offer Unity a full sample.
+                // This prevents choppy audio from playing partial samples during underrun.
+                if (valuesAvailableToRead < data.Length)
+                {
+                    _isPrimed = false;
+                    Utils.Debug($"AudioStream underrun detected, re-priming (got {valuesAvailableToRead} samples)");
+
+                    // Output silence immediately instead of playing partial/choppy samples.
+                    // On next frames, the !_isPrimed check above will ensure we wait for 30ms
+                    // of data before resuming playback smoothly.
+                    Array.Clear(data, 0, data.Length);
+                    return;
+                }
+
                 // Try to read audio samples from the ring buffer into our temp buffer.
                 // The ring buffer acts as a jitter buffer between:
                 // - Rust FFI pushing frames (on main thread, with network timing)
@@ -126,21 +142,6 @@ namespace LiveKit
                 // Calculate how many samples (shorts) were actually read from the ring buffer.
                 // If the buffer is empty or doesn't have enough data, bytesRead will be less than requested.
                 int samplesRead = bytesRead / sizeof(short);
-
-                // Underrun detection: If we couldn't read enough samples, immediately output silence
-                // and wait for the buffer to refill enough to offer Unity a full sample.
-                // This prevents choppy audio from playing partial samples during underrun.
-                if (samplesRead < data.Length)
-                {
-                    _isPrimed = false;
-                    Utils.Debug($"AudioStream underrun detected, re-priming (got {samplesRead}/{data.Length} samples)");
-
-                    // Output silence immediately instead of playing partial/choppy samples.
-                    // On next frames, the !_isPrimed check above will ensure we wait for 30ms
-                    // of data before resuming playback smoothly.
-                    Array.Clear(data, 0, data.Length);
-                    return;
-                }
 
                 // Clear the entire output buffer to silence, then fill with the samples
                 // we successfully read from the ring buffer.

--- a/Runtime/Scripts/AudioStream.cs
+++ b/Runtime/Scripts/AudioStream.cs
@@ -29,6 +29,10 @@ namespace LiveKit
         private const float BufferSizeSeconds = 0.2f;  // 200ms ring buffer for all platforms
         private const float PrimingThresholdSeconds = 0.03f;  // Wait for 30ms of data before playing
 
+        // Drift correction: skip samples when buffer fills up due to clock drift
+        private const float HighWaterMarkPercent = 0.50f;    // Target 50% fill level after correction
+        private const float SkipPerCallbackPercent = 0.05f;  // Skip 5% of callback samples per call
+
         /// <summary>
         /// Creates a new audio stream from a remote audio track, attaching it to the
         /// given <see cref="AudioSource"/> in the scene.
@@ -142,6 +146,22 @@ namespace LiveKit
                 // Calculate how many samples (shorts) were actually read from the ring buffer.
                 // If the buffer is empty or doesn't have enough data, bytesRead will be less than requested.
                 int samplesRead = bytesRead / sizeof(short);
+
+                // Drift correction: if buffer is filling up (producer faster than consumer),
+                // skip a small number of samples to prevent overflow and keep latency bounded.
+                int highWaterBytes = (int)(_buffer.Capacity * HighWaterMarkPercent);
+                int remainingBytes = _buffer.AvailableRead();
+                if (remainingBytes > highWaterBytes)
+                {
+                    int skipBytes = (int)(data.Length * sizeof(short) * SkipPerCallbackPercent);
+                    int frameSize = channels * sizeof(short);
+                    skipBytes -= skipBytes % frameSize; // align to frame boundary
+
+                    if (skipBytes > 0)
+                    {
+                        _buffer.SkipRead(skipBytes);
+                    }
+                }                
 
                 // Clear the entire output buffer to silence, then fill with the samples
                 // we successfully read from the ring buffer.

--- a/Runtime/Scripts/Internal/RingBuffer.cs
+++ b/Runtime/Scripts/Internal/RingBuffer.cs
@@ -135,6 +135,8 @@ namespace LiveKit.Internal
             return (float)AvailableRead() / _buffer.Length;
         }
 
+        public int Capacity => _buffer.Length;
+
         public float AvailableWriteInPercent()
         {
             return (float)AvailableWrite() / _buffer.Length;

--- a/Runtime/Scripts/Internal/RingBuffer.cs
+++ b/Runtime/Scripts/Internal/RingBuffer.cs
@@ -130,6 +130,16 @@ namespace LiveKit.Internal
             return _buffer.Length - AvailableRead();
         }
 
+        public float AvailableReadInPercent()
+        {
+            return (float)AvailableRead() / _buffer.Length;
+        }
+
+        public float AvailableWriteInPercent()
+        {
+            return (float)AvailableWrite() / _buffer.Length;
+        }
+
         /// <summary>
         /// Clears all data from the ring buffer, resetting read and write positions.
         /// Useful when resuming from background to discard stale audio data.


### PR DESCRIPTION
Since we merged
https://github.com/livekit/client-sdk-unity/pull/198/changes#diff-ab16de9768def77346ac0bc3e6ebc2cb95c10853f5d857fab22222025438e4da 
data can not be stale in the ring buffer due to old callbacks firing from the main dispatch queue. Callbacks are always up to date, so we can simplify some things.

Also minor improvements to underrun conditions.

I also added a catchup logic to the ring buffer. If it is above 50% fill, it will skip 5% on every read to consume faster.

=========================================

Also here is the prove that with main thread skip, data keeps flowing in when app is backgrounded:

Both measurements are already skipping the main dispatch, so data keeps coming in when backgrounded.
Left without clear, right with clear:

<img width="1831" height="800" alt="Screenshot 2026-04-01 at 17 03 22" src="https://github.com/user-attachments/assets/f37b6776-2524-455b-bfc6-d98365c2313b" />
