### PR TITLE
Audio ring buffer catchup logic if too full

### DIFF
--- a/Runtime/Scripts/AudioStream.cs
+++ b/Runtime/Scripts/AudioStream.cs
@@ -29,6 +29,12 @@ namespace LiveKit
         private const float BufferSizeSeconds = 0.2f;  // 200ms ring buffer for all platforms
         private const float PrimingThresholdSeconds = 0.03f;  // Wait for 30ms of data before playing
 
+        // Drift correction: skip samples when buffer fills up due to clock drift
+        private const float HighWaterMarkPercent = 0.80f;       // Start correcting at 70% fill
+        private const float TargetFillPercent = 0.40f;          // Target fill level after correction
+        private const float MaxSkipPerCallbackPercent = 0.05f;  // Skip at most 5% of callback samples per call
+        private float _lastSkipLogTime = 0f;
+
         /// <summary>
         /// Creates a new audio stream from a remote audio track, attaching it to the
         /// given <see cref="AudioSource"/> in the scene.
@@ -142,6 +148,33 @@ namespace LiveKit
                 // Calculate how many samples (shorts) were actually read from the ring buffer.
                 // If the buffer is empty or doesn't have enough data, bytesRead will be less than requested.
                 int samplesRead = bytesRead / sizeof(short);
+
+                // Drift correction: if buffer is filling up (producer faster than consumer),
+                // skip a small number of samples to prevent overflow and keep latency bounded.
+                int highWaterBytes = (int)(_buffer.Capacity * HighWaterMarkPercent);
+                int remainingBytes = _buffer.AvailableRead();
+                if (remainingBytes > highWaterBytes)
+                {
+                    int targetBytes = (int)(_buffer.Capacity * TargetFillPercent);
+                    int excessBytes = remainingBytes - targetBytes;
+                    int maxSkipBytes = (int)(data.Length * sizeof(short) * MaxSkipPerCallbackPercent);
+                    int skipBytes = Math.Min(excessBytes, maxSkipBytes);
+                    int frameSize = channels * sizeof(short);
+                    skipBytes -= skipBytes % frameSize; // align to frame boundary
+
+                    if (skipBytes > 0)
+                    {
+                        _buffer.SkipRead(skipBytes);
+
+                        float now = Time.realtimeSinceStartup;
+                        if (now - _lastSkipLogTime > 1f)
+                        {
+                            _lastSkipLogTime = now;
+                            float fillPercent = _buffer.AvailableReadInPercent() * 100f;
+                            Utils.Debug($"AudioStream drift correction: skipped {skipBytes / sizeof(short)} samples, buffer fill now {fillPercent:F1}%");
+                        }
+                    }
+                }                
 
                 // Clear the entire output buffer to silence, then fill with the samples
                 // we successfully read from the ring buffer.

--- a/Runtime/Scripts/AudioStream.cs
+++ b/Runtime/Scripts/AudioStream.cs
@@ -30,10 +30,8 @@ namespace LiveKit
         private const float PrimingThresholdSeconds = 0.03f;  // Wait for 30ms of data before playing
 
         // Drift correction: skip samples when buffer fills up due to clock drift
-        private const float HighWaterMarkPercent = 0.80f;       // Start correcting at 70% fill
-        private const float TargetFillPercent = 0.40f;          // Target fill level after correction
-        private const float MaxSkipPerCallbackPercent = 0.05f;  // Skip at most 5% of callback samples per call
-        private float _lastSkipLogTime = 0f;
+        private const float HighWaterMarkPercent = 0.50f;    // Target 50% fill level after correction
+        private const float SkipPerCallbackPercent = 0.05f;  // Skip 5% of callback samples per call
 
         /// <summary>
         /// Creates a new audio stream from a remote audio track, attaching it to the
@@ -155,24 +153,13 @@ namespace LiveKit
                 int remainingBytes = _buffer.AvailableRead();
                 if (remainingBytes > highWaterBytes)
                 {
-                    int targetBytes = (int)(_buffer.Capacity * TargetFillPercent);
-                    int excessBytes = remainingBytes - targetBytes;
-                    int maxSkipBytes = (int)(data.Length * sizeof(short) * MaxSkipPerCallbackPercent);
-                    int skipBytes = Math.Min(excessBytes, maxSkipBytes);
+                    int skipBytes = (int)(data.Length * sizeof(short) * SkipPerCallbackPercent);
                     int frameSize = channels * sizeof(short);
                     skipBytes -= skipBytes % frameSize; // align to frame boundary
 
                     if (skipBytes > 0)
                     {
                         _buffer.SkipRead(skipBytes);
-
-                        float now = Time.realtimeSinceStartup;
-                        if (now - _lastSkipLogTime > 1f)
-                        {
-                            _lastSkipLogTime = now;
-                            float fillPercent = _buffer.AvailableReadInPercent() * 100f;
-                            Utils.Debug($"AudioStream drift correction: skipped {skipBytes / sizeof(short)} samples, buffer fill now {fillPercent:F1}%");
-                        }
                     }
                 }                
 

--- a/Runtime/Scripts/Internal/RingBuffer.cs
+++ b/Runtime/Scripts/Internal/RingBuffer.cs
@@ -135,6 +135,8 @@ namespace LiveKit.Internal
             return (float)AvailableRead() / _buffer.Length;
         }
 
+        public int Capacity => _buffer.Length;
+
         public float AvailableWriteInPercent()
         {
             return (float)AvailableWrite() / _buffer.Length;


### PR DESCRIPTION
### Background

We have a audio ring buffer of 200ms. If frames are produced faster than being consumed the buffer fills up and we read with latency. Also future writes might have to drop frames because there is no space to write to.

### Changes

If the audio ring buffer fills up above 50% we increase consumption speed by skipping 5% in each read until we are below 50% again. 
Instead of dropping frames on write and also reading with a lot of latency because the buffer is full, we drop frames when reading to catch up and reduce latency.
