### PR TITLE
SuperPR: Simplification of code

### DIFF
--- a/Runtime/Scripts/Internal/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFIClient.cs
@@ -26,7 +26,7 @@ namespace LiveKit.Internal
 
         internal SynchronizationContext? _context;
 
-        private static bool _isDisposed = false;
+        private static volatile bool _isDisposed = false;
 
         private readonly IObjectPool<FfiResponse> ffiResponsePool;
         private readonly MessageParser<FfiResponse> responseParser;
@@ -54,7 +54,7 @@ namespace LiveKit.Internal
         public event TrackEventReceivedDelegate? TrackEventReceived;
         public event RpcMethodInvocationReceivedDelegate? RpcMethodInvocationReceived;
 
-        // participant events are not allowed in the fii protocol public event ParticipantEventReceivedDelegate ParticipantEventReceived;
+        // Participant events are not exposed in the FFI protocol; they arrive as RoomEvents instead.
         public event VideoStreamEventReceivedDelegate? VideoStreamEventReceived;
         public event AudioStreamEventReceivedDelegate? AudioStreamEventReceived;
 

--- a/Runtime/Scripts/Internal/FFIClients/FfiRequestExtensions.cs
+++ b/Runtime/Scripts/Internal/FFIClients/FfiRequestExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using System.Runtime.CompilerServices;
 using System.Reflection;
@@ -11,6 +12,7 @@ namespace LiveKit.Internal.FFIClients
     {
         private static long nextRequestAsyncId;
         private static readonly ConcurrentDictionary<Type, Action<object, ulong>?> requestAsyncIdSetters = new();
+        private static readonly ConcurrentDictionary<Type, Action<FfiRequest, object>> injectors = new();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong InitializeRequestAsyncId<T>(this T request)
@@ -71,303 +73,43 @@ namespace LiveKit.Internal.FFIClients
             return requestAsyncId;
         }
 
+        /// <summary>
+        /// Sets the appropriate oneof field on <paramref name="ffiRequest"/> to <paramref name="request"/>.
+        /// </summary>
+        /// <remarks>
+        /// Uses the same reflection + caching approach as <see cref="InitializeRequestAsyncId{T}"/>.
+        /// Each concrete request type is matched to the FfiRequest property whose type equals it.
+        /// Protobuf oneof fields generate exactly one property per variant type, so the match is
+        /// unambiguous. The first call for a given type pays the reflection cost; subsequent calls
+        /// reuse the cached delegate.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Inject<T>(this FfiRequest ffiRequest, T request)
         {
-            switch (request)
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var injector = injectors.GetOrAdd(request.GetType(), static type =>
             {
-                case DisposeRequest disposeRequest:
-                    ffiRequest.Dispose = disposeRequest;
-                    break;
-                // Room
-                case ConnectRequest connectRequest:
-                    ffiRequest.Connect = connectRequest;
-                    break;
-                case DisconnectRequest disconnectRequest:
-                    ffiRequest.Disconnect = disconnectRequest;
-                    break;
-                case PublishTrackRequest publishTrackRequest:
-                    ffiRequest.PublishTrack = publishTrackRequest;
-                    break;
-                case UnpublishTrackRequest unpublishTrackRequest:
-                    ffiRequest.UnpublishTrack = unpublishTrackRequest;
-                    break;
-                case PublishDataRequest publishDataRequest:
-                    ffiRequest.PublishData = publishDataRequest;
-                    break;
-                case SetSubscribedRequest setSubscribedRequest:
-                    ffiRequest.SetSubscribed = setSubscribedRequest;
-                    break;
-                case SetLocalMetadataRequest updateLocalMetadataRequest:
-                    ffiRequest.SetLocalMetadata = updateLocalMetadataRequest;
-                    break;
-                case SetLocalNameRequest updateLocalNameRequest:
-                    ffiRequest.SetLocalName = updateLocalNameRequest;
-                    break;
-                case SetLocalAttributesRequest setLocalAttributesRequest:
-                    ffiRequest.SetLocalAttributes = setLocalAttributesRequest;
-                    break;
-                case GetSessionStatsRequest getSessionStatsRequest:
-                    ffiRequest.GetSessionStats = getSessionStatsRequest;
-                    break;
-                // Track
-                case CreateVideoTrackRequest createVideoTrackRequest:
-                    ffiRequest.CreateVideoTrack = createVideoTrackRequest;
-                    break;
-                case CreateAudioTrackRequest createAudioTrackRequest:
-                    ffiRequest.CreateAudioTrack = createAudioTrackRequest;
-                    break;
-                case GetStatsRequest getStatsRequest:
-                    ffiRequest.GetStats = getStatsRequest;
-                    break;
-                // Video
-                case NewVideoStreamRequest newVideoStreamRequest:
-                    ffiRequest.NewVideoStream = newVideoStreamRequest;
-                    break;
-                case NewVideoSourceRequest newVideoSourceRequest:
-                    ffiRequest.NewVideoSource = newVideoSourceRequest;
-                    break;
-                case CaptureVideoFrameRequest captureVideoFrameRequest:
-                    ffiRequest.CaptureVideoFrame = captureVideoFrameRequest;
-                    break;
-                case VideoConvertRequest videoConvertRequest:
-                    ffiRequest.VideoConvert = videoConvertRequest;
-                    break;
-                // Audio
-                case NewAudioStreamRequest newAudioStreamRequest:
-                    ffiRequest.NewAudioStream = newAudioStreamRequest;
-                    break;
-                case NewAudioSourceRequest newAudioSourceRequest:
-                    ffiRequest.NewAudioSource = newAudioSourceRequest;
-                    break;
-                case CaptureAudioFrameRequest captureAudioFrameRequest:
-                    ffiRequest.CaptureAudioFrame = captureAudioFrameRequest;
-                    break;
-                case NewAudioResamplerRequest newAudioResamplerRequest:
-                    ffiRequest.NewAudioResampler = newAudioResamplerRequest;
-                    break;
-                case RemixAndResampleRequest remixAndResampleRequest:
-                    ffiRequest.RemixAndResample = remixAndResampleRequest;
-                    break;
-                case LocalTrackMuteRequest localTrackMuteRequest:
-                    ffiRequest.LocalTrackMute = localTrackMuteRequest;
-                    break;
-                case E2eeRequest e2EeRequest:
-                    ffiRequest.E2Ee = e2EeRequest;
-                    break;
-                // Rpc
-                case RegisterRpcMethodRequest registerRpcMethodRequest:
-                    ffiRequest.RegisterRpcMethod = registerRpcMethodRequest;
-                    break;
-                case UnregisterRpcMethodRequest unregisterRpcMethodRequest:
-                    ffiRequest.UnregisterRpcMethod = unregisterRpcMethodRequest;
-                    break;
-                case PerformRpcRequest performRpcRequest:
-                    ffiRequest.PerformRpc = performRpcRequest;
-                    break;
-                case RpcMethodInvocationResponseRequest rpcMethodInvocationResponseRequest:
-                    ffiRequest.RpcMethodInvocationResponse = rpcMethodInvocationResponseRequest;
-                    break;
-                // Data stream
-                case TextStreamReaderReadIncrementalRequest textStreamReaderReadIncrementalRequest:
-                    ffiRequest.TextReadIncremental = textStreamReaderReadIncrementalRequest;
-                    break;
-                case TextStreamReaderReadAllRequest textStreamReaderReadAllRequest:
-                    ffiRequest.TextReadAll = textStreamReaderReadAllRequest;
-                    break;
-                case ByteStreamReaderReadIncrementalRequest byteStreamReaderReadIncrementalRequest:
-                    ffiRequest.ByteReadIncremental = byteStreamReaderReadIncrementalRequest;
-                    break;
-                case ByteStreamReaderReadAllRequest byteStreamReaderReadAllRequest:
-                    ffiRequest.ByteReadAll = byteStreamReaderReadAllRequest;
-                    break;
-                case ByteStreamReaderWriteToFileRequest byteStreamReaderWriteToFileRequest:
-                    ffiRequest.ByteWriteToFile = byteStreamReaderWriteToFileRequest;
-                    break;
-                case StreamSendFileRequest streamSendFileRequest:
-                    ffiRequest.SendFile = streamSendFileRequest;
-                    break;
-                case StreamSendTextRequest streamSendTextRequest:
-                    ffiRequest.SendText = streamSendTextRequest;
-                    break;
-                case ByteStreamOpenRequest byteStreamOpenRequest:
-                    ffiRequest.ByteStreamOpen = byteStreamOpenRequest;
-                    break;
-                case ByteStreamWriterWriteRequest byteStreamWriterWriteRequest:
-                    ffiRequest.ByteStreamWrite = byteStreamWriterWriteRequest;
-                    break;
-                case ByteStreamWriterCloseRequest byteStreamWriterCloseRequest:
-                    ffiRequest.ByteStreamClose = byteStreamWriterCloseRequest;
-                    break;
-                case TextStreamOpenRequest textStreamOpenRequest:
-                    ffiRequest.TextStreamOpen = textStreamOpenRequest;
-                    break;
-                case TextStreamWriterWriteRequest textStreamWriterWriteRequest:
-                    ffiRequest.TextStreamWrite = textStreamWriterWriteRequest;
-                    break;
-                case TextStreamWriterCloseRequest textStreamWriterCloseRequest:
-                    ffiRequest.TextStreamClose = textStreamWriterCloseRequest;
-                    break;
-                case SetRemoteTrackPublicationQualityRequest setRemoteTrackPublicationQualityRequest:
-                    ffiRequest.SetRemoteTrackPublicationQuality = setRemoteTrackPublicationQualityRequest;
-                    break;
-                // Data Track
-                case PublishDataTrackRequest publishDataTrackRequest:
-                    ffiRequest.PublishDataTrack = publishDataTrackRequest;
-                    break;
-                case LocalDataTrackTryPushRequest localDataTrackTryPushRequest:
-                    ffiRequest.LocalDataTrackTryPush = localDataTrackTryPushRequest;
-                    break;
-                case LocalDataTrackUnpublishRequest localDataTrackUnpublishRequest:
-                    ffiRequest.LocalDataTrackUnpublish = localDataTrackUnpublishRequest;
-                    break;
-                case LocalDataTrackIsPublishedRequest localDataTrackIsPublishedRequest:
-                    ffiRequest.LocalDataTrackIsPublished = localDataTrackIsPublishedRequest;
-                    break;
-                case SubscribeDataTrackRequest subscribeDataTrackRequest:
-                    ffiRequest.SubscribeDataTrack = subscribeDataTrackRequest;
-                    break;
-                case RemoteDataTrackIsPublishedRequest remoteDataTrackIsPublishedRequest:
-                    ffiRequest.RemoteDataTrackIsPublished = remoteDataTrackIsPublishedRequest;
-                    break;
-                case DataTrackStreamReadRequest dataTrackStreamReadRequest:
-                    ffiRequest.DataTrackStreamRead = dataTrackStreamReadRequest;
-                    break;
-                default:
-                    throw new Exception($"Unknown request type: {request?.GetType().FullName ?? "null"}");
-            }
-        }
+                const BindingFlags flags = BindingFlags.Instance | BindingFlags.Public;
+                var property = typeof(FfiRequest).GetProperties(flags)
+                    .FirstOrDefault(p => p.PropertyType == type && p.CanWrite);
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void EnsureClean(this FfiRequest request)
-        {
-            // list of messages is taken from: livekit-ffi/protocol/ffi.proto
-            // https://github.com/livekit/rust-sdks/blob/cf34856e78892a639c4d3c1d6a27e9aba0a4a8ff/livekit-ffi/protocol/ffi.proto#L4
+                if (property == null)
+                    throw new InvalidOperationException(
+                        $"No FfiRequest property found for type {type.FullName}");
 
-            if (
-                request.Dispose != null
-                ||
+                return (req, val) => property.SetValue(req, val);
+            });
 
-                // Room
-                request.Connect != null
-                || request.Disconnect != null
-                || request.PublishTrack != null
-                || request.UnpublishTrack != null
-                || request.PublishData != null
-                || request.SetSubscribed != null
-                || request.SetLocalMetadata != null
-                || request.SetLocalName != null
-                || request.SetLocalAttributes != null
-                || request.GetSessionStats != null
-                ||
-
-                // Track
-                request.CreateVideoTrack != null
-                || request.CreateAudioTrack != null
-                || request.GetStats != null
-                ||
-
-                // Video
-                request.NewVideoStream != null
-                || request.NewVideoSource != null
-                || request.CaptureVideoFrame != null
-                || request.VideoConvert != null
-                ||
-
-                // Audio
-                request.NewAudioStream != null
-                || request.NewAudioSource != null
-                || request.CaptureAudioFrame != null
-                || request.NewAudioResampler != null
-                || request.RemixAndResample != null
-                || request.E2Ee != null
-                ||
-
-                // Rpc
-                request.RegisterRpcMethod != null
-                || request.UnregisterRpcMethod != null
-                || request.PerformRpc != null
-                || request.RpcMethodInvocationResponse != null
-                ||
-
-                // Data Track
-                request.PublishDataTrack != null
-                || request.LocalDataTrackTryPush != null
-                || request.LocalDataTrackUnpublish != null
-                || request.LocalDataTrackIsPublished != null
-                || request.SubscribeDataTrack != null
-                || request.RemoteDataTrackIsPublished != null
-                || request.DataTrackStreamRead != null
-            )
-            {
-                throw new InvalidOperationException("Request is not cleared");
-            }
+            injector(ffiRequest, request);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void EnsureClean(this FfiResponse response)
         {
-            // list of messages is taken from: livekit-ffi/protocol/ffi.proto
-            // https://github.com/livekit/rust-sdks/blob/cf34856e78892a639c4d3c1d6a27e9aba0a4a8ff/livekit-ffi/protocol/ffi.proto#L4
-
-            if (
-                response.Dispose != null
-                ||
-
-                // Room
-                response.Connect != null
-                || response.Disconnect != null
-                || response.PublishTrack != null
-                || response.UnpublishTrack != null
-                || response.PublishData != null
-                || response.SetSubscribed != null
-                || response.SetLocalMetadata != null
-                || response.SetLocalName != null
-                || response.SetLocalAttributes != null
-                || response.GetSessionStats != null
-                ||
-
-                // Track
-                response.CreateVideoTrack != null
-                || response.CreateAudioTrack != null
-                || response.GetStats != null
-                ||
-
-                // Video
-                response.NewVideoStream != null
-                || response.NewVideoSource != null
-                || response.CaptureVideoFrame != null
-                || response.VideoConvert != null
-                ||
-
-                // Audio
-                response.NewAudioStream != null
-                || response.NewAudioSource != null
-                || response.CaptureAudioFrame != null
-                || response.NewAudioResampler != null
-                || response.RemixAndResample != null
-                || response.E2Ee != null
-                ||
-
-                // Rpc
-                response.RegisterRpcMethod != null
-                || response.UnregisterRpcMethod != null
-                || response.PerformRpc != null
-                || response.RpcMethodInvocationResponse != null
-                ||
-
-                // Data Track
-                response.PublishDataTrack != null
-                || response.LocalDataTrackTryPush != null
-                || response.LocalDataTrackUnpublish != null
-                || response.LocalDataTrackIsPublished != null
-                || response.SubscribeDataTrack != null
-                || response.RemoteDataTrackIsPublished != null
-                || response.DataTrackStreamRead != null
-            )
-            {
-                throw new InvalidOperationException("Response is not cleared: ");
-            }
+            if (response.MessageCase != FfiResponse.MessageOneofCase.None)
+                throw new InvalidOperationException("Response is not cleared");
         }
     }
 }

--- a/Runtime/Scripts/Internal/FFIClients/Pools/ThreadSafeMultiPool.cs
+++ b/Runtime/Scripts/Internal/FFIClients/Pools/ThreadSafeMultiPool.cs
@@ -21,13 +21,8 @@ namespace LiveKit.Internal.FFIClients.Pools
 
         private IObjectPool<object> Pool<T>() where T : class, new()
         {
-            var type = typeof(T);
-            if (!pools.TryGetValue(type, out var pool))
-            {
-                pool = pools[type] = new ThreadSafeObjectPool<object>(() => new T());
-            }
-
-            return pool!;
+            return pools.GetOrAdd(typeof(T),
+                _ => new ThreadSafeObjectPool<object>(() => new T()));
         }
     }
 }

--- a/Runtime/Scripts/Internal/FfiInstruction.cs
+++ b/Runtime/Scripts/Internal/FfiInstruction.cs
@@ -1,0 +1,35 @@
+using System;
+using LiveKit.Proto;
+
+namespace LiveKit
+{
+    /// <summary>
+    /// Generic one-shot async instruction for FFI operations that only need
+    /// error/done status from the callback.
+    /// </summary>
+    /// <typeparam name="TCallback">The protobuf callback type returned by Rust.</typeparam>
+    public sealed class FfiInstruction<TCallback> : YieldInstruction where TCallback : class
+    {
+        internal FfiInstruction(
+            ulong asyncId,
+            Func<FfiEvent, TCallback?> selector,
+            Func<TCallback, string?> errorExtractor)
+        {
+            Internal.FfiClient.Instance.RegisterPendingCallback(
+                asyncId,
+                selector,
+                callback =>
+                {
+                    var error = errorExtractor(callback);
+                    IsError = !string.IsNullOrEmpty(error);
+                    IsDone = true;
+                },
+                () =>
+                {
+                    IsError = true;
+                    IsDone = true;
+                }
+            );
+        }
+    }
+}

--- a/Runtime/Scripts/Internal/FfiInstruction.cs.meta
+++ b/Runtime/Scripts/Internal/FfiInstruction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 655d4eefc2c6a425788c490e32552790
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -81,7 +81,7 @@ namespace LiveKit
             return instruction;
         }
 
-        public UnpublishTrackInstruction UnpublishTrack(ILocalTrack localTrack, bool stopOnUnpublish)
+        public FfiInstruction<UnpublishTrackCallback> UnpublishTrack(ILocalTrack localTrack, bool stopOnUnpublish)
         {
             if (!Room.TryGetTarget(out var room))
                 throw new Exception("room is invalid");
@@ -91,7 +91,10 @@ namespace LiveKit
             unpublish.LocalParticipantHandle = (ulong)Handle.DangerousGetHandle();
             unpublish.StopOnUnpublish = false;
             unpublish.TrackSid = localTrack.Sid;
-            var instruction = new UnpublishTrackInstruction(request.RequestAsyncId);
+            var instruction = new FfiInstruction<UnpublishTrackCallback>(
+                request.RequestAsyncId,
+                static e => e.UnpublishTrack,
+                static e => e.Error);
             using var response = request.Send();
             _tracks.Remove(localTrack.Sid);
             return instruction;
@@ -132,14 +135,17 @@ namespace LiveKit
         /// This requires `canUpdateOwnMetadata` permission.
         /// </remarks>
         /// <param name="metadata">The new metadata.</param>
-        public SetLocalMetadataInstruction SetMetadata(string metadata)
+        public FfiInstruction<SetLocalMetadataCallback> SetMetadata(string metadata)
         {
             using var request = FFIBridge.Instance.NewRequest<SetLocalMetadataRequest>();
             var setReq = request.request;
             setReq.LocalParticipantHandle = (ulong)Handle.DangerousGetHandle();
             setReq.Metadata = metadata;
 
-            var instruction = new SetLocalMetadataInstruction(request.RequestAsyncId);
+            var instruction = new FfiInstruction<SetLocalMetadataCallback>(
+                request.RequestAsyncId,
+                static e => e.SetLocalMetadata,
+                static e => e.Error);
             using var response = request.Send();
             return instruction;
         }
@@ -151,14 +157,17 @@ namespace LiveKit
         /// This requires `canUpdateOwnMetadata` permission.
         /// </remarks>
         /// <param name="name">The new name.</param>
-        public new SetLocalNameInstruction SetName(string name)
+        public new FfiInstruction<SetLocalNameCallback> SetName(string name)
         {
             using var request = FFIBridge.Instance.NewRequest<SetLocalNameRequest>();
             var setReq = request.request;
             setReq.LocalParticipantHandle = (ulong)Handle.DangerousGetHandle();
             setReq.Name = name;
 
-            var instruction = new SetLocalNameInstruction(request.RequestAsyncId);
+            var instruction = new FfiInstruction<SetLocalNameCallback>(
+                request.RequestAsyncId,
+                static e => e.SetLocalName,
+                static e => e.Error);
             using var response = request.Send();
             return instruction;
         }
@@ -171,7 +180,7 @@ namespace LiveKit
         /// </remarks>
         /// <param name="attributes">The new attributes. Existing attributes that
         /// are not overridden will remain unchanged.</param>
-        public SetLocalAttributesInstruction SetAttributes(IDictionary<string, string> attributes)
+        public FfiInstruction<SetLocalAttributesCallback> SetAttributes(IDictionary<string, string> attributes)
         {
             using var request = FFIBridge.Instance.NewRequest<SetLocalAttributesRequest>();
             var setReq = request.request;
@@ -194,7 +203,10 @@ namespace LiveKit
                 setReq.Attributes.Add(entry);
             }
 
-            var instruction = new SetLocalAttributesInstruction(request.RequestAsyncId);
+            var instruction = new FfiInstruction<SetLocalAttributesCallback>(
+                request.RequestAsyncId,
+                static e => e.SetLocalAttributes,
+                static e => e.Error);
             using var response = request.Send();
             return instruction;
         }
@@ -629,109 +641,6 @@ namespace LiveKit
         }
     }
 
-    public sealed class SetLocalMetadataInstruction : YieldInstruction
-    {
-        private ulong _asyncId;
-
-        internal SetLocalMetadataInstruction(ulong asyncId)
-        {
-            _asyncId = asyncId;
-            FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.SetLocalMetadata, OnSetLocalMetadata, OnCanceled);
-        }
-
-        internal void OnSetLocalMetadata(SetLocalMetadataCallback e)
-        {
-            if (e.AsyncId != _asyncId)
-                return;
-
-            IsError = !string.IsNullOrEmpty(e.Error);
-            IsDone = true;
-        }
-
-        void OnCanceled()
-        {
-            IsError = true;
-            IsDone = true;
-        }
-    }
-
-    public sealed class SetLocalNameInstruction : YieldInstruction
-    {
-        private ulong _asyncId;
-
-        internal SetLocalNameInstruction(ulong asyncId)
-        {
-            _asyncId = asyncId;
-            FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.SetLocalName, OnSetLocalName, OnCanceled);
-        }
-
-        internal void OnSetLocalName(SetLocalNameCallback e)
-        {
-            if (e.AsyncId != _asyncId)
-                return;
-
-            IsError = !string.IsNullOrEmpty(e.Error);
-            IsDone = true;
-        }
-
-        void OnCanceled()
-        {
-            IsError = true;
-            IsDone = true;
-        }
-    }
-
-    public sealed class SetLocalAttributesInstruction : YieldInstruction
-    {
-        private ulong _asyncId;
-
-        internal SetLocalAttributesInstruction(ulong asyncId)
-        {
-            _asyncId = asyncId;
-            FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.SetLocalAttributes, OnSetLocalAttributes, OnCanceled);
-        }
-
-        internal void OnSetLocalAttributes(SetLocalAttributesCallback e)
-        {
-            if (e.AsyncId != _asyncId)
-                return;
-
-            IsError = !string.IsNullOrEmpty(e.Error);
-            IsDone = true;
-        }
-
-        void OnCanceled()
-        {
-            IsError = true;
-            IsDone = true;
-        }
-    }
-
-    public sealed class UnpublishTrackInstruction : YieldInstruction
-    {
-        private ulong _asyncId;
-
-        internal UnpublishTrackInstruction(ulong asyncId)
-        {
-            _asyncId = asyncId;
-            FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.UnpublishTrack, OnUnpublish, OnCanceled);
-        }
-
-        internal void OnUnpublish(UnpublishTrackCallback e)
-        {
-            if (e.AsyncId != _asyncId)
-                return;
-
-            IsError = !string.IsNullOrEmpty(e.Error);
-            IsDone = true;
-        }
-
-        void OnCanceled()
-        {
-            IsError = true;
-            IsDone = true;
-        }
-    }
 
     /// <summary>
     /// YieldInstruction for RPC calls. Returned by <see cref="LocalParticipant.PerformRpc"/>.


### PR DESCRIPTION
### Background

We might have duplicated code, too convoluted classes, etc. I wanted to see what we can find and fix with Claude

### Changes
                                                                                                                                         
  - Replace Inject() 165-line type-dispatch switch with cached reflection — new request types added to the proto no longer require manual switch-case additions. Uses the same reflection + caching pattern     
  already established by InitializeRequestAsyncId in the same file.
  - Replace EnsureClean() null-check chains with protobuf oneof check — two methods (130 lines combined) that manually checked 30+ fields each are replaced by a single 2-line method using MessageCase != None.
   The FfiRequest overload was removed entirely as it had no call sites.                                                                                                                                        
  - Consolidate 4 identical instruction classes into generic FfiInstruction<TCallback> — SetLocalMetadataInstruction, SetLocalNameInstruction, SetLocalAttributesInstruction, and UnpublishTrackInstruction were
   character-for-character identical. A single generic class replaces all of them. Complex instruction classes (e.g., PublishTrackInstruction, PerformRpcInstruction) are unchanged.                            
  - Minor fixes: mark _isDisposed as volatile for cross-thread visibility, fix garbled comment in FFIClient.cs, fix non-atomic pool creation race in ThreadSafeMultiPool.
                                                                                                                                                                                                                
  Breaking changes                                          
                                                                                                                                                                                                                
  Return types of SetMetadata(), SetName(), SetAttributes(), and UnpublishTrack() on LocalParticipant changed from concrete instruction types to FfiInstruction<T>. Callers using yield return or var are       
  unaffected since the base type (YieldInstruction) is unchanged.