### PR TITLE
Fix null participant in ActiveSpeakersChanged list

### DIFF
--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -432,7 +432,11 @@ namespace LiveKit
                         var speakers = new List<Participant>(identities.Count);
 
                         foreach (var id in identities)
-                            speakers.Add(GetParticipant(id));
+                        {
+                            var participant = GetParticipant(id);
+                            if (participant != null)
+                                speakers.Add(participant);
+                        }
 
                         ActiveSpeakersChanged?.Invoke(speakers);
                     }


### PR DESCRIPTION
### Background

GetParticipant() can return null if the identity is unknown. The speakers list was adding nulls without checking, which could cause NullReferenceException in event handlers.

### Changes

What did you do?

- Check for null