### PR TITLE
Fix NullReferenceException in RTCConfiguration.ToProto()

### DIFF
--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -43,7 +43,7 @@ namespace LiveKit
     {
         IceTransportType IceTransportType = IceTransportType.TRANSPORT_ALL;
         ContinualGatheringPolicy ContinualGatheringPolicy = ContinualGatheringPolicy.GATHER_ONCE;
-        IceServer[] IceServers;
+        IceServer[] IceServers = System.Array.Empty<IceServer>();
 
         public Proto.RtcConfig ToProto()
         {


### PR DESCRIPTION
### Background

IceServers field was never initialized, so calling ToProto() without explicitly setting it would throw when iterating.

### Changes

What did you do?

- Init IceServers array with empty array.