### PR TITLE
Fix null dereference in TrackSubscribed handler

### DIFF
--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -356,11 +356,6 @@ namespace LiveKit
                         var participant = RemoteParticipants[e.TrackSubscribed.ParticipantIdentity];
                         var publication = participant.Tracks[info.Sid];
 
-                        if (publication == null)
-                        {
-                            participant._tracks.Add(publication.Sid, publication);
-                        }
-
                         if (info.Kind == TrackKind.KindVideo)
                         {
                             var videoTrack = new RemoteVideoTrack(track, this, participant);


### PR DESCRIPTION
### Background

The code checked if publication was null, then immediately accessed publication.Sid — causing a NullReferenceException. The block was also logically inverted (adding a null to the dictionary). The publication should already exist from a prior TrackPublished event, so the dead block is removed.
