### PR TITLE
Fix event handler leak on room disconnect

### DIFF
--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -557,6 +557,7 @@ namespace LiveKit
         private void OnDisconnect()
         {
             FfiClient.Instance.RoomEventReceived -= OnEventReceived;
+            FfiClient.Instance.RpcMethodInvocationReceived -= OnRpcMethodInvocationReceived;
         }
 
         internal RemoteParticipant CreateRemoteParticipantWithTracks(ConnectCallback.Types.ParticipantWithTracks item)


### PR DESCRIPTION
### Background

RpcMethodInvocationReceived was subscribed in OnConnect but never unsubscribed in OnDisconnect, leaking the handler on each reconnect cycle. DisconnectReceived already unsubscribes itself in its own handler.

### Changes

- Unsubscribe on disconnect