### PR TITLE
Mark _muted and _disposed as volatile in RtcAudioSource

### DIFF
--- a/Runtime/Scripts/RtcAudioSource.cs
+++ b/Runtime/Scripts/RtcAudioSource.cs
@@ -76,11 +76,11 @@ namespace LiveKit
         private readonly Dictionary<ulong, PendingAudioFrame> _pendingFrameData = new();
         private readonly object _pendingFrameDataLock = new object();
 
-        private bool _muted = false;
+        private volatile bool _muted = false;
         public override bool Muted => _muted;
 
         private bool _started = false;
-        private bool _disposed = false;
+        private volatile bool _disposed = false;
         private int _audioReadCount = 0;
 
         protected RtcAudioSource(int channels = 2, RtcAudioSourceType audioSourceType = RtcAudioSourceType.AudioSourceCustom)


### PR DESCRIPTION
### Background

These fields are written on the main thread (SetMute, Dispose) and read on the audio callback thread (OnAudioRead). Without volatile, the audio thread may not see updates promptly. Volatile forces the value to be read from memory instead of potentially the CPU cache.

### Changes

What did you do?

- mark `_muted` and `_disposed` as volatile