### PR TITLE
Add generic FfiInstruction base classes, simplify 8 instruction types

### DIFF
--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -693,37 +693,10 @@ namespace LiveKit
         /// <remarks>
         /// Check if the operation was successful by accessing <see cref="Error"/>.
         /// </remarks>
-        public sealed class WriteInstruction : YieldInstruction
+        public sealed class WriteInstruction : FfiStreamInstruction<TextStreamWriterWriteCallback>
         {
-            private ulong _asyncId;
-
             internal WriteInstruction(ulong asyncId)
-            {
-                _asyncId = asyncId;
-                FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.TextStreamWriterWrite, OnWrite, OnCanceled);
-            }
-
-            internal void OnWrite(TextStreamWriterWriteCallback e)
-            {
-                if (e.AsyncId != _asyncId)
-                    return;
-
-                if (e.Error != null)
-                {
-                    Error = new StreamError(e.Error);
-                    IsError = true;
-                }
-                IsDone = true;
-            }
-
-            void OnCanceled()
-            {
-                Error = new StreamError("Canceled");
-                IsError = true;
-                IsDone = true;
-            }
-
-            public StreamError Error { get; private set; }
+                : base(asyncId, static e => e.TextStreamWriterWrite, static e => e.Error) { }
         }
 
         /// <summary>
@@ -732,37 +705,10 @@ namespace LiveKit
         /// <remarks>
         /// Check if the operation was successful by accessing <see cref="Error"/>.
         /// </remarks>
-        public sealed class CloseInstruction : YieldInstruction
+        public sealed class CloseInstruction : FfiStreamInstruction<TextStreamWriterCloseCallback>
         {
-            private ulong _asyncId;
-
             internal CloseInstruction(ulong asyncId)
-            {
-                _asyncId = asyncId;
-                FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.TextStreamWriterClose, OnClose, OnCanceled);
-            }
-
-            internal void OnClose(TextStreamWriterCloseCallback e)
-            {
-                if (e.AsyncId != _asyncId)
-                    return;
-
-                if (e.Error != null)
-                {
-                    Error = new StreamError(e.Error);
-                    IsError = true;
-                }
-                IsDone = true;
-            }
-
-            void OnCanceled()
-            {
-                Error = new StreamError("Canceled");
-                IsError = true;
-                IsDone = true;
-            }
-
-            public StreamError Error { get; private set; }
+                : base(asyncId, static e => e.TextStreamWriterClose, static e => e.Error) { }
         }
     }
 
@@ -826,37 +772,10 @@ namespace LiveKit
         /// <remarks>
         /// Check if the operation was successful by accessing <see cref="Error"/>.
         /// </remarks>
-        public sealed class WriteInstruction : YieldInstruction
+        public sealed class WriteInstruction : FfiStreamInstruction<ByteStreamWriterWriteCallback>
         {
-            private ulong _asyncId;
-
             internal WriteInstruction(ulong asyncId)
-            {
-                _asyncId = asyncId;
-                FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.ByteStreamWriterWrite, OnWrite, OnCanceled);
-            }
-
-            internal void OnWrite(ByteStreamWriterWriteCallback e)
-            {
-                if (e.AsyncId != _asyncId)
-                    return;
-
-                if (e.Error != null)
-                {
-                    Error = new StreamError(e.Error);
-                    IsError = true;
-                }
-                IsDone = true;
-            }
-
-            void OnCanceled()
-            {
-                Error = new StreamError("Canceled");
-                IsError = true;
-                IsDone = true;
-            }
-
-            public StreamError Error { get; private set; }
+                : base(asyncId, static e => e.ByteStreamWriterWrite, static e => e.Error) { }
         }
 
         /// <summary>
@@ -865,37 +784,10 @@ namespace LiveKit
         /// <remarks>
         /// Check if the operation was successful by accessing <see cref="Error"/>.
         /// </remarks>
-        public sealed class CloseInstruction : YieldInstruction
+        public sealed class CloseInstruction : FfiStreamInstruction<ByteStreamWriterCloseCallback>
         {
-            private ulong _asyncId;
-
             internal CloseInstruction(ulong asyncId)
-            {
-                _asyncId = asyncId;
-                FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.ByteStreamWriterClose, OnClose, OnCanceled);
-            }
-
-            internal void OnClose(ByteStreamWriterCloseCallback e)
-            {
-                if (e.AsyncId != _asyncId)
-                    return;
-
-                if (e.Error != null)
-                {
-                    Error = new StreamError(e.Error);
-                    IsError = true;
-                }
-                IsDone = true;
-            }
-
-            void OnCanceled()
-            {
-                Error = new StreamError("Canceled");
-                IsError = true;
-                IsDone = true;
-            }
-
-            public StreamError Error { get; private set; }
+                : base(asyncId, static e => e.ByteStreamWriterClose, static e => e.Error) { }
         }
     }
 

--- a/Runtime/Scripts/Internal/FfiInstruction.cs
+++ b/Runtime/Scripts/Internal/FfiInstruction.cs
@@ -1,0 +1,69 @@
+using System;
+using LiveKit.Internal;
+using LiveKit.Proto;
+
+namespace LiveKit
+{
+    /// <summary>
+    /// Generic yield instruction for one-shot FFI callbacks that follow the standard pattern:
+    /// register a pending callback, check for a string error on completion, set IsDone.
+    /// </summary>
+    /// <typeparam name="TCallback">The protobuf callback type (e.g. SetLocalMetadataCallback).</typeparam>
+    public class FfiInstruction<TCallback> : YieldInstruction where TCallback : class
+    {
+        internal FfiInstruction(
+            ulong asyncId,
+            Func<FfiEvent, TCallback> selector,
+            Func<TCallback, string> errorExtractor)
+        {
+            FfiClient.Instance.RegisterPendingCallback(
+                asyncId,
+                selector,
+                e =>
+                {
+                    IsError = !string.IsNullOrEmpty(errorExtractor(e));
+                    IsDone = true;
+                },
+                () =>
+                {
+                    IsError = true;
+                    IsDone = true;
+                });
+        }
+    }
+
+    /// <summary>
+    /// Generic yield instruction for one-shot FFI callbacks that expose a <see cref="StreamError"/>.
+    /// </summary>
+    /// <typeparam name="TCallback">The protobuf callback type (e.g. TextStreamWriterWriteCallback).</typeparam>
+    public class FfiStreamInstruction<TCallback> : YieldInstruction where TCallback : class
+    {
+        public StreamError Error { get; private set; }
+
+        internal FfiStreamInstruction(
+            ulong asyncId,
+            Func<FfiEvent, TCallback> selector,
+            Func<TCallback, Proto.StreamError> errorExtractor)
+        {
+            FfiClient.Instance.RegisterPendingCallback(
+                asyncId,
+                selector,
+                e =>
+                {
+                    var protoError = errorExtractor(e);
+                    if (protoError != null)
+                    {
+                        Error = new StreamError(protoError);
+                        IsError = true;
+                    }
+                    IsDone = true;
+                },
+                () =>
+                {
+                    Error = new StreamError("Canceled");
+                    IsError = true;
+                    IsDone = true;
+                });
+        }
+    }
+}

--- a/Runtime/Scripts/Internal/FfiInstruction.cs.meta
+++ b/Runtime/Scripts/Internal/FfiInstruction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b0370500a2ec4dbca4bc0a4f43adb86
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -629,108 +629,28 @@ namespace LiveKit
         }
     }
 
-    public sealed class SetLocalMetadataInstruction : YieldInstruction
+    public sealed class SetLocalMetadataInstruction : FfiInstruction<SetLocalMetadataCallback>
     {
-        private ulong _asyncId;
-
         internal SetLocalMetadataInstruction(ulong asyncId)
-        {
-            _asyncId = asyncId;
-            FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.SetLocalMetadata, OnSetLocalMetadata, OnCanceled);
-        }
-
-        internal void OnSetLocalMetadata(SetLocalMetadataCallback e)
-        {
-            if (e.AsyncId != _asyncId)
-                return;
-
-            IsError = !string.IsNullOrEmpty(e.Error);
-            IsDone = true;
-        }
-
-        void OnCanceled()
-        {
-            IsError = true;
-            IsDone = true;
-        }
+            : base(asyncId, static e => e.SetLocalMetadata, static e => e.Error) { }
     }
 
-    public sealed class SetLocalNameInstruction : YieldInstruction
+    public sealed class SetLocalNameInstruction : FfiInstruction<SetLocalNameCallback>
     {
-        private ulong _asyncId;
-
         internal SetLocalNameInstruction(ulong asyncId)
-        {
-            _asyncId = asyncId;
-            FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.SetLocalName, OnSetLocalName, OnCanceled);
-        }
-
-        internal void OnSetLocalName(SetLocalNameCallback e)
-        {
-            if (e.AsyncId != _asyncId)
-                return;
-
-            IsError = !string.IsNullOrEmpty(e.Error);
-            IsDone = true;
-        }
-
-        void OnCanceled()
-        {
-            IsError = true;
-            IsDone = true;
-        }
+            : base(asyncId, static e => e.SetLocalName, static e => e.Error) { }
     }
 
-    public sealed class SetLocalAttributesInstruction : YieldInstruction
+    public sealed class SetLocalAttributesInstruction : FfiInstruction<SetLocalAttributesCallback>
     {
-        private ulong _asyncId;
-
         internal SetLocalAttributesInstruction(ulong asyncId)
-        {
-            _asyncId = asyncId;
-            FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.SetLocalAttributes, OnSetLocalAttributes, OnCanceled);
-        }
-
-        internal void OnSetLocalAttributes(SetLocalAttributesCallback e)
-        {
-            if (e.AsyncId != _asyncId)
-                return;
-
-            IsError = !string.IsNullOrEmpty(e.Error);
-            IsDone = true;
-        }
-
-        void OnCanceled()
-        {
-            IsError = true;
-            IsDone = true;
-        }
+            : base(asyncId, static e => e.SetLocalAttributes, static e => e.Error) { }
     }
 
-    public sealed class UnpublishTrackInstruction : YieldInstruction
+    public sealed class UnpublishTrackInstruction : FfiInstruction<UnpublishTrackCallback>
     {
-        private ulong _asyncId;
-
         internal UnpublishTrackInstruction(ulong asyncId)
-        {
-            _asyncId = asyncId;
-            FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.UnpublishTrack, OnUnpublish, OnCanceled);
-        }
-
-        internal void OnUnpublish(UnpublishTrackCallback e)
-        {
-            if (e.AsyncId != _asyncId)
-                return;
-
-            IsError = !string.IsNullOrEmpty(e.Error);
-            IsDone = true;
-        }
-
-        void OnCanceled()
-        {
-            IsError = true;
-            IsDone = true;
-        }
+            : base(asyncId, static e => e.UnpublishTrack, static e => e.Error) { }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Introduce `FfiInstruction<TCallback>` and `FfiStreamInstruction<TCallback>` as generic base classes in `Runtime/Scripts/Internal/FfiInstruction.cs` for the common one-shot FFI callback pattern (register callback, check error, set IsDone).
- Replace 8 boilerplate instruction classes (`SetLocalMetadataInstruction`, `SetLocalNameInstruction`, `SetLocalAttributesInstruction`, `UnpublishTrackInstruction`, and the `WriteInstruction`/`CloseInstruction` pairs in both `TextStreamWriter` and `ByteStreamWriter`) with thin subclasses that delegate to the generic base.
- Net reduction of ~120 lines of duplicated code with no behavioral change.

## Test plan
- [ ] Verify existing unit/integration tests pass (the 8 simplified instruction types have identical runtime behavior)
- [ ] Confirm `SetMetadata`, `SetName`, `SetAttributes`, `UnpublishTrack` still work in a live room
- [ ] Confirm text/byte stream `Write` and `Close` operations still complete correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)