### PR TITLE
Code Scan Fix: Remove redundant AsyncId checks from instruction callbacks

### DIFF
--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -182,12 +182,10 @@ namespace LiveKit
         /// </remarks>
         public sealed class ReadAllInstruction : YieldInstruction
         {
-            private ulong _asyncId;
             private string _text;
 
             internal ReadAllInstruction(ulong asyncId)
             {
-                _asyncId = asyncId;
                 // ReadAll is modeled as a single async completion rather than a stream of
                 // incremental events, so it uses the request_async_id pending map. Rust returns
                 // the same value through callback.AsyncId.
@@ -196,9 +194,6 @@ namespace LiveKit
 
             internal void OnReadAll(TextStreamReaderReadAllCallback e)
             {
-                if (e.AsyncId != _asyncId)
-                    return;
-
                 switch (e.ResultCase)
                 {
                     case TextStreamReaderReadAllCallback.ResultOneofCase.Error:
@@ -395,20 +390,15 @@ namespace LiveKit
         /// </remarks>
         public sealed class ReadAllInstruction : YieldInstruction
         {
-            private ulong _asyncId;
             private byte[] _bytes;
 
             internal ReadAllInstruction(ulong asyncId)
             {
-                _asyncId = asyncId;
                 FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.ByteStreamReaderReadAll, OnReadAll, OnCanceled);
             }
 
             internal void OnReadAll(ByteStreamReaderReadAllCallback e)
             {
-                if (e.AsyncId != _asyncId)
-                    return;
-
                 switch (e.ResultCase)
                 {
                     case ByteStreamReaderReadAllCallback.ResultOneofCase.Error:
@@ -509,20 +499,15 @@ namespace LiveKit
         /// </remarks>
         public sealed class WriteToFileInstruction : YieldInstruction
         {
-            private ulong _asyncId;
             private string _filePath;
 
             internal WriteToFileInstruction(ulong asyncId)
             {
-                _asyncId = asyncId;
                 FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.ByteStreamReaderWriteToFile, OnWriteToFile, OnCanceled);
             }
 
             internal void OnWriteToFile(ByteStreamReaderWriteToFileCallback e)
             {
-                if (e.AsyncId != _asyncId)
-                    return;
-
                 switch (e.ResultCase)
                 {
                     case ByteStreamReaderWriteToFileCallback.ResultOneofCase.Error:

--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -594,13 +594,11 @@ namespace LiveKit
 
     public sealed class PublishTrackInstruction : YieldInstruction
     {
-        private ulong _asyncId;
         private Dictionary<string, TrackPublication> _internalTracks;
         private ILocalTrack _localTrack;
 
         internal PublishTrackInstruction(ulong asyncId, ILocalTrack localTrack, Dictionary<string, TrackPublication> internalTracks)
         {
-            _asyncId = asyncId;
             _internalTracks = internalTracks;
             _localTrack = localTrack;
             // One-shot completion keyed by request_async_id. Concurrent requests simply occupy
@@ -611,9 +609,6 @@ namespace LiveKit
 
         internal void OnPublish(PublishTrackCallback e)
         {
-            if (e.AsyncId != _asyncId)
-                return;
-
             IsError = !string.IsNullOrEmpty(e.Error);
             IsDone = true;
             var publication = new LocalTrackPublication(e.Publication.Info);
@@ -741,21 +736,15 @@ namespace LiveKit
     /// </remarks>
     public sealed class PerformRpcInstruction : YieldInstruction
     {
-        private ulong _asyncId;
         private string _payload;
 
         internal PerformRpcInstruction(ulong asyncId)
         {
-            _asyncId = asyncId;
             FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.PerformRpc, OnRpcResponse, OnCanceled);
         }
 
         internal void OnRpcResponse(PerformRpcCallback e)
         {
-            if (e.AsyncId != _asyncId)
-                return;
-
-
             if (e.Error != null)
             {
                 Error = RpcError.FromProto(e.Error);
@@ -807,20 +796,15 @@ namespace LiveKit
     /// </remarks>
     public sealed class SendTextInstruction : YieldInstruction
     {
-        private ulong _asyncId;
         private TextStreamInfo _info;
 
         internal SendTextInstruction(ulong asyncId)
         {
-            _asyncId = asyncId;
             FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.SendText, OnSendText, OnCanceled);
         }
 
         internal void OnSendText(StreamSendTextCallback e)
         {
-            if (e.AsyncId != _asyncId)
-                return;
-
             switch (e.ResultCase)
             {
                 case StreamSendTextCallback.ResultOneofCase.Error:
@@ -861,20 +845,15 @@ namespace LiveKit
     /// </remarks>
     public sealed class SendFileInstruction : YieldInstruction
     {
-        private ulong _asyncId;
         private ByteStreamInfo _info;
 
         internal SendFileInstruction(ulong asyncId)
         {
-            _asyncId = asyncId;
             FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.SendFile, OnSendFile, OnCanceled);
         }
 
         internal void OnSendFile(StreamSendFileCallback e)
         {
-            if (e.AsyncId != _asyncId)
-                return;
-
             switch (e.ResultCase)
             {
                 case StreamSendFileCallback.ResultOneofCase.Error:
@@ -915,20 +894,15 @@ namespace LiveKit
     /// </remarks>
     public sealed class StreamTextInstruction : YieldInstruction
     {
-        private ulong _asyncId;
         private TextStreamWriter _writer;
 
         internal StreamTextInstruction(ulong asyncId)
         {
-            _asyncId = asyncId;
             FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.TextStreamOpen, OnStreamOpen, OnCanceled);
         }
 
         internal void OnStreamOpen(TextStreamOpenCallback e)
         {
-            if (e.AsyncId != _asyncId)
-                return;
-
             switch (e.ResultCase)
             {
                 case TextStreamOpenCallback.ResultOneofCase.Error:
@@ -969,20 +943,15 @@ namespace LiveKit
     /// </remarks>
     public sealed class StreamBytesInstruction : YieldInstruction
     {
-        private ulong _asyncId;
         private ByteStreamWriter _writer;
 
         internal StreamBytesInstruction(ulong asyncId)
         {
-            _asyncId = asyncId;
             FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.ByteStreamOpen, OnStreamOpen, OnCanceled);
         }
 
         internal void OnStreamOpen(ByteStreamOpenCallback e)
         {
-            if (e.AsyncId != _asyncId)
-                return;
-
             switch (e.ResultCase)
             {
                 case ByteStreamOpenCallback.ResultOneofCase.Error:
@@ -1023,20 +992,15 @@ namespace LiveKit
     /// </remarks>
     public sealed class PublishDataTrackInstruction : YieldInstruction
     {
-        private ulong _asyncId;
         private LocalDataTrack _track;
 
         internal PublishDataTrackInstruction(ulong asyncId)
         {
-            _asyncId = asyncId;
             FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.PublishDataTrack, OnPublishDataTrack, OnCanceled);
         }
 
         internal void OnPublishDataTrack(PublishDataTrackCallback e)
         {
-            if (e.AsyncId != _asyncId)
-                return;
-
             switch (e.ResultCase)
             {
                 case PublishDataTrackCallback.ResultOneofCase.Error:

--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -593,13 +593,11 @@ namespace LiveKit
 
     public sealed class ConnectInstruction : YieldInstruction
     {
-        private ulong _asyncId;
         private Room _room;
         private RoomOptions _roomOptions;
 
         internal ConnectInstruction(ulong asyncId, Room room, RoomOptions options)
         {
-            _asyncId = asyncId;
             _room = room;
             _roomOptions = options;
             // Register before the request is sent so a fast native completion cannot race ahead
@@ -610,9 +608,6 @@ namespace LiveKit
 
         void OnConnect(ConnectCallback e)
         {
-            if (_asyncId != e.AsyncId)
-                return;
-
             bool success = string.IsNullOrEmpty(e.Error);
             if (success)
             {

--- a/Runtime/Scripts/Track.cs
+++ b/Runtime/Scripts/Track.cs
@@ -171,13 +171,11 @@ namespace LiveKit
     
     public sealed class GetSessionStatsInstruction : YieldInstruction
     {
-        private readonly ulong _asyncId;
         public RtcStats[] Stats;
         public string Error;
 
         internal GetSessionStatsInstruction(ulong asyncId)
         {
-            _asyncId = asyncId;
             // This waiter is a one-shot response; cancellation and completion race through the
             // same pending entry, so only one path can finish the instruction.
             FfiClient.Instance.RegisterPendingCallback(asyncId, static e => e.GetStats, OnGetSessionStatsReceived, OnCanceled);
@@ -185,9 +183,6 @@ namespace LiveKit
 
         private void OnGetSessionStatsReceived(GetStatsCallback e)
         {
-            if (e.AsyncId != _asyncId)
-                return;
-
             Error = e.Error;
             IsError = !string.IsNullOrEmpty(Error);
             IsDone = true;


### PR DESCRIPTION
## Summary
- `FfiClient.TryDispatchPendingCallback()` already matches callbacks by `requestAsyncId` via `ConcurrentDictionary.TryRemove` before invoking the callback, so the per-instruction `if (e.AsyncId != _asyncId) return;` guard was dead code.
- Removed the stored `_asyncId` field, assignment, and guard from all 12 custom instruction classes across `Participant.cs`, `Room.cs`, `Track.cs`, and `DataStream.cs`.
- The `asyncId` constructor parameter is kept since it is still passed to `RegisterPendingCallback`.

## Test plan
- [ ] Verify CI passes (existing unit/integration tests cover the affected instruction classes)
- [ ] Manual smoke test: connect to a room, publish a track, perform RPC, send text/file streams, and confirm all callbacks still fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)