### PR TITLE
Implement IDisposable on stream readers/writers

### DIFF
--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -166,7 +166,7 @@ namespace LiveKit
         /// </returns>
         public ReadAllInstruction ReadAll()
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<TextStreamReaderReadAllRequest>();
             var readAllReq = request.request;
             readAllReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -248,7 +248,7 @@ namespace LiveKit
         /// </returns>
         public ReadIncrementalInstruction ReadIncremental()
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<TextStreamReaderReadIncrementalRequest>();
             var readIncReq = request.request;
             readIncReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -347,7 +347,7 @@ namespace LiveKit
         /// </returns>
         public ReadAllInstruction ReadAll()
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamReaderReadAllRequest>();
             var readAllReq = request.request;
             readAllReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -365,7 +365,7 @@ namespace LiveKit
         /// </returns>
         public ReadIncrementalInstruction ReadIncremental()
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamReaderReadIncrementalRequest>();
             var readIncReq = request.request;
             readIncReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -389,7 +389,7 @@ namespace LiveKit
         /// </returns>
         public WriteToFileInstruction WriteToFile(string directory = null, string nameOverride = null)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamReaderWriteToFileRequest>();
             var writeToFileReq = request.request;
             writeToFileReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -679,7 +679,7 @@ namespace LiveKit
         /// </returns>
         public WriteInstruction Write(string text)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<TextStreamWriterWriteRequest>();
             var writeReq = request.request;
             writeReq.WriterHandle = (ulong)_handle.DangerousGetHandle();
@@ -700,7 +700,7 @@ namespace LiveKit
         /// </returns>
         public CloseInstruction Close(string reason = null)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<TextStreamWriterCloseRequest>();
             var closeReq = request.request;
             closeReq.WriterHandle = (ulong)_handle.DangerousGetHandle();
@@ -823,7 +823,7 @@ namespace LiveKit
         /// </returns>
         public WriteInstruction Write(byte[] bytes)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamWriterWriteRequest>();
             var writeReq = request.request;
             writeReq.WriterHandle = (ulong)_handle.DangerousGetHandle();
@@ -843,7 +843,7 @@ namespace LiveKit
         /// </returns>
         public CloseInstruction Close(string reason = null)
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamWriterCloseRequest>();
             var closeReq = request.request;
             closeReq.WriterHandle = (ulong)_handle.DangerousGetHandle();

--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -140,10 +140,11 @@ namespace LiveKit
     /// <summary>
     /// Reader for an incoming text data stream.
     /// </summary>
-    public sealed class TextStreamReader
+    public sealed class TextStreamReader : IDisposable
     {
         private readonly FfiHandle _handle;
         private readonly TextStreamInfo _info;
+        private bool _disposed;
 
         internal TextStreamReader(OwnedTextStreamReader info)
         {
@@ -165,6 +166,7 @@ namespace LiveKit
         /// </returns>
         public ReadAllInstruction ReadAll()
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             using var request = FFIBridge.Instance.NewRequest<TextStreamReaderReadAllRequest>();
             var readAllReq = request.request;
             readAllReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -172,6 +174,13 @@ namespace LiveKit
             var instruction = new ReadAllInstruction(request.RequestAsyncId);
             using var response = request.Send();
             return instruction;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _handle?.Dispose();
         }
 
         /// <summary>
@@ -239,6 +248,7 @@ namespace LiveKit
         /// </returns>
         public ReadIncrementalInstruction ReadIncremental()
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             using var request = FFIBridge.Instance.NewRequest<TextStreamReaderReadIncrementalRequest>();
             var readIncReq = request.request;
             readIncReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -311,10 +321,11 @@ namespace LiveKit
     /// <summary>
     /// Reader for an incoming byte data stream.
     /// </summary>
-    public sealed class ByteStreamReader
+    public sealed class ByteStreamReader : IDisposable
     {
         private FfiHandle _handle;
         private readonly ByteStreamInfo _info;
+        private bool _disposed;
 
         internal ByteStreamReader(OwnedByteStreamReader info)
         {
@@ -336,6 +347,7 @@ namespace LiveKit
         /// </returns>
         public ReadAllInstruction ReadAll()
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamReaderReadAllRequest>();
             var readAllReq = request.request;
             readAllReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -353,6 +365,7 @@ namespace LiveKit
         /// </returns>
         public ReadIncrementalInstruction ReadIncremental()
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamReaderReadIncrementalRequest>();
             var readIncReq = request.request;
             readIncReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -376,6 +389,7 @@ namespace LiveKit
         /// </returns>
         public WriteToFileInstruction WriteToFile(string directory = null, string nameOverride = null)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamReaderWriteToFileRequest>();
             var writeToFileReq = request.request;
             writeToFileReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
@@ -385,6 +399,13 @@ namespace LiveKit
             var instruction = new WriteToFileInstruction(request.RequestAsyncId);
             using var response = request.Send();
             return instruction;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _handle?.Dispose();
         }
 
         /// <summary>
@@ -634,10 +655,11 @@ namespace LiveKit
     /// <summary>
     /// Writer for an outgoing text data stream.
     /// </summary>
-    public class TextStreamWriter
+    public class TextStreamWriter : IDisposable
     {
         private FfiHandle _handle;
         private readonly TextStreamInfo _info;
+        private bool _disposed;
 
         internal TextStreamWriter(OwnedTextStreamWriter info)
         {
@@ -657,6 +679,7 @@ namespace LiveKit
         /// </returns>
         public WriteInstruction Write(string text)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             using var request = FFIBridge.Instance.NewRequest<TextStreamWriterWriteRequest>();
             var writeReq = request.request;
             writeReq.WriterHandle = (ulong)_handle.DangerousGetHandle();
@@ -677,6 +700,7 @@ namespace LiveKit
         /// </returns>
         public CloseInstruction Close(string reason = null)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             using var request = FFIBridge.Instance.NewRequest<TextStreamWriterCloseRequest>();
             var closeReq = request.request;
             closeReq.WriterHandle = (ulong)_handle.DangerousGetHandle();
@@ -764,15 +788,23 @@ namespace LiveKit
 
             public StreamError Error { get; private set; }
         }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _handle?.Dispose();
+        }
     }
 
     /// <summary>
     /// Writer for an outgoing byte data stream.
     /// </summary>
-    public class ByteStreamWriter
+    public class ByteStreamWriter : IDisposable
     {
         private FfiHandle _handle;
         private readonly ByteStreamInfo _info;
+        private bool _disposed;
 
         internal ByteStreamWriter(OwnedByteStreamWriter info)
         {
@@ -791,6 +823,7 @@ namespace LiveKit
         /// </returns>
         public WriteInstruction Write(byte[] bytes)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamWriterWriteRequest>();
             var writeReq = request.request;
             writeReq.WriterHandle = (ulong)_handle.DangerousGetHandle();
@@ -810,6 +843,7 @@ namespace LiveKit
         /// </returns>
         public CloseInstruction Close(string reason = null)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamWriterCloseRequest>();
             var closeReq = request.request;
             closeReq.WriterHandle = (ulong)_handle.DangerousGetHandle();
@@ -896,6 +930,13 @@ namespace LiveKit
             }
 
             public StreamError Error { get; private set; }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _handle?.Dispose();
         }
     }
 

--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -477,14 +477,22 @@ namespace LiveKit
                     }
                     break;
                 case RoomEvent.MessageOneofCase.ByteStreamOpened:
-                    var byteReader = new ByteStreamReader(e.ByteStreamOpened.Reader);
-                    _streamHandlers.Dispatch(byteReader, e.ByteStreamOpened.ParticipantIdentity);
-                    // TODO: Immediately dispose unhandled stream reader
+                    {
+                        var byteReader = new ByteStreamReader(e.ByteStreamOpened.Reader);
+                        if (!_streamHandlers.Dispatch(byteReader, e.ByteStreamOpened.ParticipantIdentity))
+                        {
+                            byteReader.Dispose();
+                        }
+                    }
                     break;
                 case RoomEvent.MessageOneofCase.TextStreamOpened:
-                    var textReader = new TextStreamReader(e.TextStreamOpened.Reader);
-                    _streamHandlers.Dispatch(textReader, e.TextStreamOpened.ParticipantIdentity);
-                    // TODO: Immediately dispose unhandled stream reader
+                    {
+                        var textReader = new TextStreamReader(e.TextStreamOpened.Reader);
+                        if (!_streamHandlers.Dispatch(textReader, e.TextStreamOpened.ParticipantIdentity))
+                        {
+                            textReader.Dispose();
+                        }
+                    }
                     break;
                 case RoomEvent.MessageOneofCase.ConnectionStateChanged:
                     ConnectionState = e.ConnectionStateChanged.State;


### PR DESCRIPTION
### Background

`TextStreamReader`, `ByteStreamReader`, `TextStreamWriter`, and `ByteStreamWriter` hold native FFI handles but never implement `IDisposable`. If a stream is abandoned without completing (e.g., no handler registered, or user drops the object mid-stream), the native handle leaks. This also resolves the TODO comments in Room.cs about disposing unhandled stream readers.

### Changes

- Add `IDisposable` to all four stream reader/writer classes in `DataStream.cs`
- Add `ObjectDisposedException` guards to all public methods (`ReadAll`, `ReadIncremental`, `WriteToFile`, `Write`, `Close`)
- Dispose unhandled stream readers in `Room.cs` when no handler is registered for the stream's topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)