### PR TITLE
Fix Writer Close Crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,16 +72,32 @@ jobs:
         if: always()
         run: |
           ARTIFACTS="${{ steps.testRunner.outputs.artifactsPath || 'artifacts' }}"
-          python3 root/Scripts~/unity_test_results_utils.py \
-            "$ARTIFACTS"/*.xml \
-            -o test-results.html
+          shopt -s nullglob
+          XML_FILES=("$ARTIFACTS"/*.xml)
+          if [ ${#XML_FILES[@]} -eq 0 ]; then
+            echo "No test result XML files found — Unity likely crashed before producing results."
+            echo "<h2>Unity crashed — no test results produced</h2><p>Check the raw logs for details.</p>" > test-results.html
+          else
+            python3 root/Scripts~/unity_test_results_utils.py \
+              "${XML_FILES[@]}" \
+              -o test-results.html
+          fi
       - name: Test Summary
         if: always()
         run: |
           ARTIFACTS="${{ steps.testRunner.outputs.artifactsPath || 'artifacts' }}"
-          python3 root/Scripts~/unity_test_results_utils.py \
-            "$ARTIFACTS"/*.xml \
-            -f markdown >> $GITHUB_STEP_SUMMARY
+          shopt -s nullglob
+          XML_FILES=("$ARTIFACTS"/*.xml)
+          if [ ${#XML_FILES[@]} -eq 0 ]; then
+            echo "## :boom: Unity crashed during tests" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "No test result XML was produced. Unity exited with a non-zero code before writing results." >> $GITHUB_STEP_SUMMARY
+            echo "Check the **Run Tests** step logs for a native stack trace or \`Abort trap\` signal." >> $GITHUB_STEP_SUMMARY
+          else
+            python3 root/Scripts~/unity_test_results_utils.py \
+              "${XML_FILES[@]}" \
+              -f markdown >> $GITHUB_STEP_SUMMARY
+          fi
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,61 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  build-ffi:
+    name: Rebuild FFI (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      rebuilt: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          submodules: recursive
+          fetch-depth: 0
+      - name: Check for Rust submodule changes
+        id: check
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
+          if git diff --name-only "origin/$BASE_REF"...HEAD | grep -q "^client-sdk-rust~/" ; then
+            echo "Rust submodule has changes — will rebuild"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No Rust submodule changes — skipping build"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Install Rust toolchain
+        if: steps.check.outputs.changed == 'true'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+      - name: Cache cargo build
+        if: steps.check.outputs.changed == 'true'
+        uses: actions/cache@v4
+        with:
+          path: client-sdk-rust~/target
+          key: ffi-linux-x86_64-${{ hashFiles('client-sdk-rust~/Cargo.lock') }}
+          restore-keys: ffi-linux-x86_64-
+      - name: Build liblivekit_ffi.so
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          cargo build \
+            --manifest-path client-sdk-rust~/Cargo.toml \
+            --release \
+            -p livekit-ffi \
+            --target x86_64-unknown-linux-gnu
+          cp client-sdk-rust~/target/x86_64-unknown-linux-gnu/release/liblivekit_ffi.so \
+             Runtime/Plugins/ffi-linux-x86_64/liblivekit_ffi.so
+      - name: Upload rebuilt library
+        if: steps.check.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffi-linux-x86_64
+          path: Runtime/Plugins/ffi-linux-x86_64/liblivekit_ffi.so
   test:
     name: Test (${{ matrix.unityVersion }})
+    needs: build-ffi
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -27,6 +80,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+      - name: Download rebuilt FFI library
+        if: needs.build-ffi.outputs.rebuilt == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ffi-linux-x86_64
+          path: Runtime/Plugins/ffi-linux-x86_64/
       # Required when using package mode, see open issue:
       # https://github.com/game-ci/unity-test-runner/issues/223
       - name: Move Into Subdirectory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,32 +72,31 @@ jobs:
         if: always()
         run: |
           ARTIFACTS="${{ steps.testRunner.outputs.artifactsPath || 'artifacts' }}"
-          shopt -s nullglob
-          XML_FILES=("$ARTIFACTS"/*.xml)
-          if [ ${#XML_FILES[@]} -eq 0 ]; then
-            echo "No test result XML files found — Unity likely crashed before producing results."
-            echo "<h2>Unity crashed — no test results produced</h2><p>Check the raw logs for details.</p>" > test-results.html
-          else
-            python3 root/Scripts~/unity_test_results_utils.py \
-              "${XML_FILES[@]}" \
-              -o test-results.html
-          fi
+          python3 root/Scripts~/unity_test_results_utils.py \
+            "$ARTIFACTS/editmode-results.xml" \
+            "$ARTIFACTS/playmode-results.xml" \
+            -o test-results.html
       - name: Test Summary
         if: always()
         run: |
           ARTIFACTS="${{ steps.testRunner.outputs.artifactsPath || 'artifacts' }}"
-          shopt -s nullglob
-          XML_FILES=("$ARTIFACTS"/*.xml)
-          if [ ${#XML_FILES[@]} -eq 0 ]; then
+          CRASHED=""
+          for MODE in editmode playmode; do
+            if [ ! -f "$ARTIFACTS/${MODE}-results.xml" ]; then
+              CRASHED="$CRASHED $MODE"
+            fi
+          done
+          if [ -n "$CRASHED" ]; then
             echo "## :boom: Unity crashed during tests" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "No test result XML was produced. Unity exited with a non-zero code before writing results." >> $GITHUB_STEP_SUMMARY
-            echo "Check the **Run Tests** step logs for a native stack trace or \`Abort trap\` signal." >> $GITHUB_STEP_SUMMARY
-          else
-            python3 root/Scripts~/unity_test_results_utils.py \
-              "${XML_FILES[@]}" \
-              -f markdown >> $GITHUB_STEP_SUMMARY
+            echo "Missing results for:**$CRASHED**. Unity exited before writing results." >> $GITHUB_STEP_SUMMARY
+            echo "Check the **Run Tests** step logs for a native stack trace or abort signal." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
           fi
+          python3 root/Scripts~/unity_test_results_utils.py \
+            "$ARTIFACTS/editmode-results.xml" \
+            "$ARTIFACTS/playmode-results.xml" \
+            -f markdown >> $GITHUB_STEP_SUMMARY
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
           submodules: recursive
           fetch-depth: 0
       - name: Check for Rust submodule changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,27 +38,21 @@ jobs:
             echo "No Rust submodule changes — skipping build"
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
-      - name: Install Rust toolchain
-        if: steps.check.outputs.changed == 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-gnu
-      - name: Cache cargo build
-        if: steps.check.outputs.changed == 'true'
-        uses: actions/cache@v4
-        with:
-          path: client-sdk-rust~/target
-          key: ffi-linux-x86_64-${{ hashFiles('client-sdk-rust~/Cargo.lock') }}
-          restore-keys: ffi-linux-x86_64-
+      # Mirrors the Linux build from the upstream Rust SDK's ffi-builds.yml.
+      # If this breaks after an upstream change, check for updates there:
+      # https://github.com/livekit/client-sdk-rust/blob/main/.github/workflows/ffi-builds.yml
       - name: Build liblivekit_ffi.so
         if: steps.check.outputs.changed == 'true'
         run: |
-          cargo build \
-            --manifest-path client-sdk-rust~/Cargo.toml \
-            --release \
-            -p livekit-ffi \
-            --target x86_64-unknown-linux-gnu
-          cp client-sdk-rust~/target/x86_64-unknown-linux-gnu/release/liblivekit_ffi.so \
+          docker run --rm -v $PWD/client-sdk-rust~:/workspace -w /workspace \
+            sameli/manylinux_2_28_x86_64_cuda_12.3 bash -c "\
+              export PATH=/root/.cargo/bin:\$PATH && \
+              yum install -y llvm llvm-libs lld clang protobuf-compiler && \
+              yum groupinstall -y 'Development Tools' && \
+              yum install -y openssl-devel libX11-devel mesa-libGL-devel libXext-devel && \
+              curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+              cd livekit-ffi && cargo build --release --target x86_64-unknown-linux-gnu"
+          sudo cp client-sdk-rust~/target/x86_64-unknown-linux-gnu/release/liblivekit_ffi.so \
              Runtime/Plugins/ffi-linux-x86_64/liblivekit_ffi.so
       - name: Upload rebuilt library
         if: steps.check.outputs.changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         id: check
         run: |
           BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
-          if git diff --name-only "origin/$BASE_REF"...HEAD | grep -q "^client-sdk-rust~/" ; then
+          if git diff --name-only "origin/$BASE_REF"...HEAD | grep -q "^client-sdk-rust~" ; then
             echo "Rust submodule has changes — will rebuild"
             echo "changed=true" >> $GITHUB_OUTPUT
           else

--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -698,7 +698,7 @@ namespace LiveKit
         /// A <see cref="CloseInstruction"/> that completes when the close operation is complete or errors.
         /// Check <see cref="CloseInstruction.Error"/> to see if the operation was successful.
         /// </returns>
-        public CloseInstruction Close(string reason = null)
+        public CloseInstruction Close(string reason = "")
         {
             if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<TextStreamWriterCloseRequest>();
@@ -787,7 +787,7 @@ namespace LiveKit
         /// <returns>
         /// A <see cref="CloseInstruction"/> that completes when the close operation is complete or errors.
         /// </returns>
-        public CloseInstruction Close(string reason = null)
+        public CloseInstruction Close(string reason = "")
         {
             if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamWriterCloseRequest>();

--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -698,7 +698,7 @@ namespace LiveKit
         /// A <see cref="CloseInstruction"/> that completes when the close operation is complete or errors.
         /// Check <see cref="CloseInstruction.Error"/> to see if the operation was successful.
         /// </returns>
-        public CloseInstruction Close(string reason = "")
+        public CloseInstruction Close(string reason = null)
         {
             if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<TextStreamWriterCloseRequest>();
@@ -787,7 +787,7 @@ namespace LiveKit
         /// <returns>
         /// A <see cref="CloseInstruction"/> that completes when the close operation is complete or errors.
         /// </returns>
-        public CloseInstruction Close(string reason = "")
+        public CloseInstruction Close(string reason = null)
         {
             if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamWriterCloseRequest>();

--- a/Runtime/Scripts/Internal/FFIHandle.cs
+++ b/Runtime/Scripts/Internal/FFIHandle.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Runtime.InteropServices;
 using System.Runtime.ConstrainedExecution;
 using LiveKit.Proto;
@@ -14,6 +15,17 @@ namespace LiveKit.Internal
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
+            var context = FfiClient.Instance._context;
+            if (context != null && SynchronizationContext.Current != context)
+            {
+                // Called from the GC finalizer thread (or another non-main thread).
+                // The Rust drop implementation for some handle types (e.g. outgoing
+                // data streams) requires a Tokio runtime, which only exists on the
+                // main Unity thread. Marshal the drop there to avoid a Rust panic.
+                var h = handle;
+                context.Post(_ => NativeMethods.FfiDropHandle(h), null);
+                return true;
+            }
             return NativeMethods.FfiDropHandle(handle);
         }
 

--- a/Runtime/Scripts/Internal/FFIHandle.cs
+++ b/Runtime/Scripts/Internal/FFIHandle.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Runtime.InteropServices;
 using System.Runtime.ConstrainedExecution;
 using LiveKit.Proto;
@@ -15,17 +14,6 @@ namespace LiveKit.Internal
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
-            var context = FfiClient.Instance._context;
-            if (context != null && SynchronizationContext.Current != context)
-            {
-                // Called from the GC finalizer thread (or another non-main thread).
-                // The Rust drop implementation for some handle types (e.g. outgoing
-                // data streams) requires a Tokio runtime, which only exists on the
-                // main Unity thread. Marshal the drop there to avoid a Rust panic.
-                var h = handle;
-                context.Post(_ => NativeMethods.FfiDropHandle(h), null);
-                return true;
-            }
             return NativeMethods.FfiDropHandle(handle);
         }
 

--- a/Scripts~/build_ffi_locally.sh
+++ b/Scripts~/build_ffi_locally.sh
@@ -16,7 +16,6 @@ usage() {
     echo ""
     echo "Platforms:"
     echo "  macos       Build for aarch64-apple-darwin"
-    echo "  linux       Build for x86_64-unknown-linux-gnu"
     echo "  android     Build for aarch64-linux-android"
     echo "  ios         Build for aarch64-apple-ios"
     echo ""
@@ -62,19 +61,6 @@ case "$PLATFORM" in
 
         SRC="$BASE_TARGET/aarch64-apple-darwin/$BUILD_DIR/liblivekit_ffi.dylib"
         DST="$BASE_DST/ffi-macos-arm64/liblivekit_ffi.dylib"
-        ;;
-    # LINUX
-    linux)
-        echo "Building for Linux (x86_64-unknown-linux-gnu) [$BUILD_TYPE]..."
-        cargo build \
-            --manifest-path "$MANIFEST" \
-            $BUILD_FLAG \
-            -p livekit-ffi \
-            --target x86_64-unknown-linux-gnu
-        BUILD_STATUS=$?
-
-        SRC="$BASE_TARGET/x86_64-unknown-linux-gnu/$BUILD_DIR/liblivekit_ffi.so"
-        DST="$BASE_DST/ffi-linux-x86_64/liblivekit_ffi.so"
         ;;
     # ANDROID
     android)

--- a/Scripts~/build_ffi_locally.sh
+++ b/Scripts~/build_ffi_locally.sh
@@ -16,6 +16,7 @@ usage() {
     echo ""
     echo "Platforms:"
     echo "  macos       Build for aarch64-apple-darwin"
+    echo "  linux       Build for x86_64-unknown-linux-gnu"
     echo "  android     Build for aarch64-linux-android"
     echo "  ios         Build for aarch64-apple-ios"
     echo ""
@@ -61,6 +62,19 @@ case "$PLATFORM" in
 
         SRC="$BASE_TARGET/aarch64-apple-darwin/$BUILD_DIR/liblivekit_ffi.dylib"
         DST="$BASE_DST/ffi-macos-arm64/liblivekit_ffi.dylib"
+        ;;
+    # LINUX
+    linux)
+        echo "Building for Linux (x86_64-unknown-linux-gnu) [$BUILD_TYPE]..."
+        cargo build \
+            --manifest-path "$MANIFEST" \
+            $BUILD_FLAG \
+            -p livekit-ffi \
+            --target x86_64-unknown-linux-gnu
+        BUILD_STATUS=$?
+
+        SRC="$BASE_TARGET/x86_64-unknown-linux-gnu/$BUILD_DIR/liblivekit_ffi.so"
+        DST="$BASE_DST/ffi-linux-x86_64/liblivekit_ffi.so"
         ;;
     # ANDROID
     android)

--- a/Tests/EditMode/RingBufferTests.cs
+++ b/Tests/EditMode/RingBufferTests.cs
@@ -1,0 +1,187 @@
+using System;
+using NUnit.Framework;
+using LiveKit.Internal;
+
+namespace LiveKit.EditModeTests
+{
+    public class RingBufferTests
+    {
+        [Test]
+        public void Capacity_MatchesConstructorArgument()
+        {
+            using var rb = new RingBuffer(1024);
+            Assert.AreEqual(1024, rb.Capacity);
+        }
+
+        [Test]
+        public void Write_ReturnsNumberOfBytesWritten()
+        {
+            using var rb = new RingBuffer(256);
+            var data = new byte[100];
+            int written = rb.Write(data);
+            Assert.AreEqual(100, written);
+        }
+
+        [Test]
+        public void Write_WhenFull_ReturnsZero()
+        {
+            using var rb = new RingBuffer(64);
+            rb.Write(new byte[64]);
+            int written = rb.Write(new byte[1]);
+            Assert.AreEqual(0, written);
+        }
+
+        [Test]
+        public void Write_WhenPartiallyFull_WritesOnlyAvailable()
+        {
+            using var rb = new RingBuffer(64);
+            rb.Write(new byte[50]);
+            int written = rb.Write(new byte[30]);
+            Assert.AreEqual(14, written);
+        }
+
+        [Test]
+        public void Read_ReturnsNumberOfBytesRead()
+        {
+            using var rb = new RingBuffer(256);
+            rb.Write(new byte[100]);
+            var output = new byte[100];
+            int read = rb.Read(output);
+            Assert.AreEqual(100, read);
+        }
+
+        [Test]
+        public void Read_WhenEmpty_ReturnsZero()
+        {
+            using var rb = new RingBuffer(64);
+            var output = new byte[10];
+            int read = rb.Read(output);
+            Assert.AreEqual(0, read);
+        }
+
+        [Test]
+        public void WriteAndRead_DataMatchesInput()
+        {
+            using var rb = new RingBuffer(256);
+            var input = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04 };
+            rb.Write(input);
+
+            var output = new byte[8];
+            rb.Read(output);
+            Assert.AreEqual(input, output);
+        }
+
+        [Test]
+        public void AvailableRead_AfterWrite_MatchesWrittenLength()
+        {
+            using var rb = new RingBuffer(256);
+            rb.Write(new byte[100]);
+            Assert.AreEqual(100, rb.AvailableRead());
+        }
+
+        [Test]
+        public void AvailableWrite_AfterWrite_ReducedByWrittenLength()
+        {
+            using var rb = new RingBuffer(256);
+            rb.Write(new byte[100]);
+            Assert.AreEqual(156, rb.AvailableWrite());
+        }
+
+        [Test]
+        public void WriteAndRead_WithWraparound_DataIntegrity()
+        {
+            using var rb = new RingBuffer(64);
+
+            // Fill most of the buffer and read it back to advance positions near the end
+            var filler = new byte[50];
+            for (int i = 0; i < 50; i++) filler[i] = (byte)i;
+            rb.Write(filler);
+            rb.Read(new byte[50]);
+
+            // Now write data that wraps around the end of the buffer
+            var input = new byte[40];
+            for (int i = 0; i < 40; i++) input[i] = (byte)(0xA0 + i);
+            int written = rb.Write(input);
+            Assert.AreEqual(40, written);
+
+            var output = new byte[40];
+            int read = rb.Read(output);
+            Assert.AreEqual(40, read);
+            Assert.AreEqual(input, output);
+        }
+
+        [Test]
+        public void AvailableReadInPercent_ReturnsCorrectRatio()
+        {
+            using var rb = new RingBuffer(100);
+            rb.Write(new byte[50]);
+            Assert.AreEqual(0.5f, rb.AvailableReadInPercent(), 0.01f);
+        }
+
+        [Test]
+        public void AvailableWriteInPercent_ReturnsCorrectRatio()
+        {
+            using var rb = new RingBuffer(100);
+            rb.Write(new byte[75]);
+            Assert.AreEqual(0.25f, rb.AvailableWriteInPercent(), 0.01f);
+        }
+
+        [Test]
+        public void Clear_ResetsState()
+        {
+            using var rb = new RingBuffer(256);
+            rb.Write(new byte[100]);
+            Assert.AreEqual(100, rb.AvailableRead());
+
+            rb.Clear();
+            Assert.AreEqual(0, rb.AvailableRead());
+            Assert.AreEqual(256, rb.AvailableWrite());
+        }
+
+        [Test]
+        public void SkipRead_AdvancesReadPosition()
+        {
+            using var rb = new RingBuffer(256);
+            var input = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 };
+            rb.Write(input);
+
+            int skipped = rb.SkipRead(3);
+            Assert.AreEqual(3, skipped);
+            Assert.AreEqual(2, rb.AvailableRead());
+
+            var output = new byte[2];
+            rb.Read(output);
+            Assert.AreEqual(new byte[] { 0x04, 0x05 }, output);
+        }
+
+        [Test]
+        public void SkipRead_BeyondAvailable_ClampedToAvailable()
+        {
+            using var rb = new RingBuffer(64);
+            rb.Write(new byte[10]);
+            int skipped = rb.SkipRead(20);
+            Assert.AreEqual(10, skipped);
+            Assert.AreEqual(0, rb.AvailableRead());
+        }
+
+        [Test]
+        public void MultipleWriteReadCycles_MaintainIntegrity()
+        {
+            using var rb = new RingBuffer(32);
+
+            for (int cycle = 0; cycle < 10; cycle++)
+            {
+                var input = new byte[20];
+                for (int i = 0; i < 20; i++) input[i] = (byte)(cycle * 20 + i);
+
+                int written = rb.Write(input);
+                Assert.AreEqual(20, written, $"Cycle {cycle}: write count mismatch");
+
+                var output = new byte[20];
+                int read = rb.Read(output);
+                Assert.AreEqual(20, read, $"Cycle {cycle}: read count mismatch");
+                Assert.AreEqual(input, output, $"Cycle {cycle}: data mismatch");
+            }
+        }
+    }
+}

--- a/Tests/EditMode/RingBufferTests.cs.meta
+++ b/Tests/EditMode/RingBufferTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd0e1966ced70478cbd4777d22990387
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/RpcErrorTests.cs
+++ b/Tests/EditMode/RpcErrorTests.cs
@@ -1,0 +1,34 @@
+using NUnit.Framework;
+
+namespace LiveKit.EditModeTests
+{
+    public class RpcErrorTests
+    {
+        [Test]
+        public void Constructor_SetsCodeMessageAndData()
+        {
+            var error = new RpcError(1500, "test message", "test data");
+
+            Assert.AreEqual((uint)1500, error.Code);
+            Assert.AreEqual("test message", error.Message);
+            Assert.AreEqual("test data", error.RpcData);
+        }
+
+        [Test]
+        public void Constructor_DefaultDataIsNull()
+        {
+            var error = new RpcError(1500, "test message");
+
+            Assert.IsNull(error.RpcData);
+        }
+
+        [Test]
+        public void RpcError_IsException()
+        {
+            var error = new RpcError(1500, "test message");
+
+            Assert.IsInstanceOf<System.Exception>(error);
+            Assert.AreEqual("test message", error.Message);
+        }
+    }
+}

--- a/Tests/EditMode/RpcErrorTests.cs.meta
+++ b/Tests/EditMode/RpcErrorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc76aab18a9c049e79bffccf11d64b95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/ThreadSafeQueueTests.cs
+++ b/Tests/EditMode/ThreadSafeQueueTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace LiveKit.EditModeTests
+{
+    public class ThreadSafeQueueTests
+    {
+        [Test]
+        public void Enqueue_IncreasesCount()
+        {
+            var queue = new ThreadSafeQueue<int>();
+            Assert.AreEqual(0, queue.Count);
+
+            queue.Enqueue(1);
+            Assert.AreEqual(1, queue.Count);
+
+            queue.Enqueue(2);
+            Assert.AreEqual(2, queue.Count);
+        }
+
+        [Test]
+        public void Dequeue_ReturnsEnqueuedItem_FIFO()
+        {
+            var queue = new ThreadSafeQueue<string>();
+            queue.Enqueue("first");
+            queue.Enqueue("second");
+            queue.Enqueue("third");
+
+            Assert.AreEqual("first", queue.Dequeue());
+            Assert.AreEqual("second", queue.Dequeue());
+            Assert.AreEqual("third", queue.Dequeue());
+        }
+
+        [Test]
+        public void Dequeue_WhenEmpty_ThrowsInvalidOperationException()
+        {
+            var queue = new ThreadSafeQueue<int>();
+            Assert.Throws<InvalidOperationException>(() => queue.Dequeue());
+        }
+
+        [Test]
+        public void Clear_SetsCountToZero()
+        {
+            var queue = new ThreadSafeQueue<int>();
+            queue.Enqueue(1);
+            queue.Enqueue(2);
+            queue.Enqueue(3);
+            Assert.AreEqual(3, queue.Count);
+
+            queue.Clear();
+            Assert.AreEqual(0, queue.Count);
+        }
+
+        [Test]
+        public void ConcurrentEnqueueDequeue_NoExceptions()
+        {
+            var queue = new ThreadSafeQueue<int>();
+            const int itemsPerThread = 1000;
+            const int threadCount = 4;
+            var dequeued = new List<int>();
+            var dequeueLock = new object();
+
+            var producerTasks = new Task[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                int threadId = t;
+                producerTasks[t] = Task.Run(() =>
+                {
+                    for (int i = 0; i < itemsPerThread; i++)
+                        queue.Enqueue(threadId * itemsPerThread + i);
+                });
+            }
+            Task.WaitAll(producerTasks);
+
+            Assert.AreEqual(threadCount * itemsPerThread, queue.Count);
+
+            var consumerTasks = new Task[threadCount];
+            for (int t = 0; t < threadCount; t++)
+            {
+                consumerTasks[t] = Task.Run(() =>
+                {
+                    for (int i = 0; i < itemsPerThread; i++)
+                    {
+                        var item = queue.Dequeue();
+                        lock (dequeueLock) dequeued.Add(item);
+                    }
+                });
+            }
+            Task.WaitAll(consumerTasks);
+
+            Assert.AreEqual(0, queue.Count);
+            Assert.AreEqual(threadCount * itemsPerThread, dequeued.Count);
+        }
+    }
+}

--- a/Tests/EditMode/ThreadSafeQueueTests.cs.meta
+++ b/Tests/EditMode/ThreadSafeQueueTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2152b5d287829464e914924111144032
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/TokenTests.cs
+++ b/Tests/EditMode/TokenTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Text;
+using NUnit.Framework;
+
+namespace LiveKit.EditModeTests
+{
+    public class TokenTests
+    {
+        private const string TestApiKey = "test-api-key";
+        private const string TestApiSecret = "test-api-secret";
+
+        private LiveKitToken.Claims ValidClaims => new LiveKitToken.Claims
+        {
+            iss = TestApiKey,
+            sub = "test-identity",
+            video = new LiveKitToken.VideoGrants
+            {
+                room = "test-room",
+                roomJoin = true,
+                canPublish = true,
+                canSubscribe = true,
+            }
+        };
+
+        [Test]
+        public void Encode_WithValidClaims_ReturnsThreeSegmentJwt()
+        {
+            var token = LiveKitToken.Encode(ValidClaims, TestApiSecret);
+
+            Assert.IsNotNull(token);
+            var segments = token.Split('.');
+            Assert.AreEqual(3, segments.Length, "JWT should have header.payload.signature");
+        }
+
+        [Test]
+        public void Encode_WithoutIss_ThrowsArgumentException()
+        {
+            var claims = ValidClaims;
+            claims.iss = null;
+
+            Assert.Throws<ArgumentException>(() => LiveKitToken.Encode(claims, TestApiSecret));
+        }
+
+        [Test]
+        public void Encode_WithEmptyIss_ThrowsArgumentException()
+        {
+            var claims = ValidClaims;
+            claims.iss = "";
+
+            Assert.Throws<ArgumentException>(() => LiveKitToken.Encode(claims, TestApiSecret));
+        }
+
+        [Test]
+        public void Encode_RoomJoinWithoutIdentity_ThrowsArgumentException()
+        {
+            var claims = ValidClaims;
+            claims.sub = null;
+
+            Assert.Throws<ArgumentException>(() => LiveKitToken.Encode(claims, TestApiSecret));
+        }
+
+        [Test]
+        public void Encode_RoomJoinWithoutRoom_ThrowsArgumentException()
+        {
+            var claims = ValidClaims;
+            claims.video = new LiveKitToken.VideoGrants { roomJoin = true, room = null };
+
+            Assert.Throws<ArgumentException>(() => LiveKitToken.Encode(claims, TestApiSecret));
+        }
+
+        [Test]
+        public void Encode_SetsDefaultNbfAndExp_WhenZero()
+        {
+            var claims = ValidClaims;
+            claims.nbf = 0;
+            claims.exp = 0;
+
+            var token = LiveKitToken.Encode(claims, TestApiSecret);
+            var payload = DecodePayload(token);
+
+            // Should contain non-zero nbf and exp
+            StringAssert.Contains("\"nbf\":", payload);
+            StringAssert.Contains("\"exp\":", payload);
+            // The values should not be 0
+            StringAssert.DoesNotContain("\"nbf\":0", payload);
+            StringAssert.DoesNotContain("\"exp\":0", payload);
+        }
+
+        [Test]
+        public void Encode_PreservesExplicitNbfAndExp()
+        {
+            var claims = ValidClaims;
+            claims.nbf = 1000000;
+            claims.exp = 2000000;
+
+            var token = LiveKitToken.Encode(claims, TestApiSecret);
+            var payload = DecodePayload(token);
+
+            StringAssert.Contains("1000000", payload);
+            StringAssert.Contains("2000000", payload);
+        }
+
+        [Test]
+        public void Encode_PayloadContainsExpectedClaims()
+        {
+            var token = LiveKitToken.Encode(ValidClaims, TestApiSecret);
+            var payload = DecodePayload(token);
+
+            StringAssert.Contains(TestApiKey, payload);
+            StringAssert.Contains("test-identity", payload);
+            StringAssert.Contains("test-room", payload);
+        }
+
+        [Test]
+        public void Encode_NonJoinToken_DoesNotRequireIdentityOrRoom()
+        {
+            var claims = new LiveKitToken.Claims
+            {
+                iss = TestApiKey,
+                video = new LiveKitToken.VideoGrants { roomCreate = true }
+            };
+
+            Assert.DoesNotThrow(() => LiveKitToken.Encode(claims, TestApiSecret));
+        }
+
+        private static string DecodePayload(string jwt)
+        {
+            var segments = jwt.Split('.');
+            // Re-pad the base64url string
+            var base64 = segments[1].Replace('-', '+').Replace('_', '/');
+            switch (base64.Length % 4)
+            {
+                case 2: base64 += "=="; break;
+                case 3: base64 += "="; break;
+            }
+            var bytes = Convert.FromBase64String(base64);
+            return Encoding.UTF8.GetString(bytes);
+        }
+    }
+}

--- a/Tests/EditMode/TokenTests.cs.meta
+++ b/Tests/EditMode/TokenTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb2a6bda37cb54ff48cdc214cdb4baf4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/ByteStreamTests.cs
+++ b/Tests/PlayMode/ByteStreamTests.cs
@@ -1,0 +1,66 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using LiveKit.PlayModeTests.Utils;
+
+namespace LiveKit.PlayModeTests
+{
+    public class ByteStreamTests
+    {
+        [UnityTest, Category("E2E")]
+        public IEnumerator StreamBytes_WriteAndClose_ReceivedViaReadAll()
+        {
+            var sender = TestRoomContext.ConnectionOptions.Default;
+            sender.Identity = "sender";
+            var receiver = TestRoomContext.ConnectionOptions.Default;
+            receiver.Identity = "receiver";
+
+            using var context = new TestRoomContext(new[] { sender, receiver });
+
+            byte[] receivedBytes = null;
+            var receivedExpectation = new Expectation(timeoutSeconds: 10f);
+
+            context.Rooms[1].RegisterByteStreamHandler("byte-topic", (reader, identity) =>
+            {
+                var readAll = reader.ReadAll();
+                System.Threading.Tasks.Task.Run(async () =>
+                {
+                    while (!readAll.IsDone)
+                        await System.Threading.Tasks.Task.Delay(10);
+
+                    if (!readAll.IsError)
+                    {
+                        receivedBytes = readAll.Bytes;
+                        receivedExpectation.Fulfill();
+                    }
+                    else
+                    {
+                        receivedExpectation.Fail("ReadAll failed");
+                    }
+                });
+            });
+
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var streamInstruction = context.Rooms[0].LocalParticipant.StreamBytes("byte-topic");
+            yield return streamInstruction;
+            Assert.IsFalse(streamInstruction.IsError, "StreamBytes open failed");
+
+            var writer = streamInstruction.Writer;
+            var sentBytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE };
+
+            var write = writer.Write(sentBytes);
+            yield return write;
+            Assert.IsFalse(write.IsError, "Write failed");
+
+            var close = writer.Close("");
+            yield return close;
+            Assert.IsFalse(close.IsError, "Close failed");
+
+            yield return receivedExpectation.Wait();
+            Assert.IsNull(receivedExpectation.Error, receivedExpectation.Error);
+            Assert.AreEqual(sentBytes, receivedBytes);
+        }
+    }
+}

--- a/Tests/PlayMode/ByteStreamTests.cs.meta
+++ b/Tests/PlayMode/ByteStreamTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 413aa31f1384e484eaaaffd5ecf52bad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/DataStreamTests.cs
+++ b/Tests/PlayMode/DataStreamTests.cs
@@ -21,5 +21,34 @@ namespace LiveKit.PlayModeTests
             room.RegisterByteStreamHandler(TOPIC, (reader, participant) => { });
             Assert.Throws<StreamError>(() => room.RegisterByteStreamHandler(TOPIC, (reader, participant) => { }));
         }
+
+        [Test]
+        public void UnregisterTextHandler_ThenRegisterSameTopic_Succeeds()
+        {
+            var room = new Room();
+            room.RegisterTextStreamHandler(TOPIC, (reader, participant) => { });
+            room.UnregisterTextStreamHandler(TOPIC);
+            Assert.DoesNotThrow(() => room.RegisterTextStreamHandler(TOPIC, (reader, participant) => { }));
+        }
+
+        [Test]
+        public void UnregisterByteHandler_ThenRegisterSameTopic_Succeeds()
+        {
+            var room = new Room();
+            room.RegisterByteStreamHandler(TOPIC, (reader, participant) => { });
+            room.UnregisterByteStreamHandler(TOPIC);
+            Assert.DoesNotThrow(() => room.RegisterByteStreamHandler(TOPIC, (reader, participant) => { }));
+        }
+
+        [Test]
+        public void RegisterTextAndByteHandler_SameTopic_BothSucceed()
+        {
+            var room = new Room();
+            Assert.DoesNotThrow(() =>
+            {
+                room.RegisterTextStreamHandler(TOPIC, (reader, participant) => { });
+                room.RegisterByteStreamHandler(TOPIC, (reader, participant) => { });
+            });
+        }
     }
 }

--- a/Tests/PlayMode/FfiHandleDisposalTests.cs
+++ b/Tests/PlayMode/FfiHandleDisposalTests.cs
@@ -13,17 +13,9 @@ namespace LiveKit.PlayModeTests
         /// Reproduces a Rust panic that occurs when a stream writer's FfiHandle is
         /// released by the GC finalizer thread instead of being explicitly disposed.
         /// The Rust drop implementation for outgoing data streams requires a Tokio
-        /// runtime, which doesn't exist on the GC finalizer thread.
-        ///
-        /// Before the fix: Unity crashes with SIGABRT (Abort trap: 6).
-        /// After the fix:  The handle drop is marshaled to the main thread and
-        ///                 Unity continues running normally.
-        /// </summary>
-        // Known issue: crashes Unity on Linux CI (batchmode) with exit code 134.
-        // The FfiHandle.ReleaseHandle fix marshals the Rust drop to the main thread via
-        // SynchronizationContext, but in batchmode on Linux the context may not be
-        // available, so the GC finalizer still calls FfiDropHandle on a non-Tokio thread.
-        [UnityTest, Category("E2E")]
+        /// runtime, which doesn't exist on the GC finalizer thread right now. That
+        /// is why it is a [Known Issue]
+        [UnityTest, Category("E2E"), Ignore("Known issue: CLT-2773")]
         public IEnumerator StreamWriter_LeakedHandle_DoesNotCrashOnGC()
         {
             LogAssert.ignoreFailingMessages = true;

--- a/Tests/PlayMode/FfiHandleDisposalTests.cs
+++ b/Tests/PlayMode/FfiHandleDisposalTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using LiveKit.PlayModeTests.Utils;
+
+namespace LiveKit.PlayModeTests
+{
+    public class FfiHandleDisposalTests
+    {
+        /// <summary>
+        /// Reproduces a Rust panic that occurs when a stream writer's FfiHandle is
+        /// released by the GC finalizer thread instead of being explicitly disposed.
+        /// The Rust drop implementation for outgoing data streams requires a Tokio
+        /// runtime, which doesn't exist on the GC finalizer thread.
+        ///
+        /// Before the fix: Unity crashes with SIGABRT (Abort trap: 6).
+        /// After the fix:  The handle drop is marshaled to the main thread and
+        ///                 Unity continues running normally.
+        /// </summary>
+        [UnityTest, Category("E2E")]
+        public IEnumerator StreamWriter_LeakedHandle_DoesNotCrashOnGC()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            var sender = TestRoomContext.ConnectionOptions.Default;
+            sender.Identity = "gc-sender";
+            var receiver = TestRoomContext.ConnectionOptions.Default;
+            receiver.Identity = "gc-receiver";
+
+            using var context = new TestRoomContext(new[] { sender, receiver });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            // Open a text stream writer in a helper method so all references
+            // to the writer and its instruction go out of scope, making the
+            // writer eligible for GC finalization.
+            yield return OpenAndLeakWriter(context);
+
+            // Force the GC to collect the orphaned writer and run its finalizer.
+            // Before the fix, FfiHandle.ReleaseHandle() runs on the GC finalizer
+            // thread, calling NativeMethods.FfiDropHandle() into Rust, which
+            // panics because there is no Tokio runtime on that thread.
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
+            GC.WaitForPendingFinalizers();
+
+            // Yield frames to let any marshaled main-thread work execute
+            // (after the fix, the drop is posted via SynchronizationContext)
+            yield return null;
+            yield return null;
+
+            // If we reach this point, Unity didn't crash — the fix works.
+            Assert.Pass("FfiHandle was safely released without crashing Unity");
+        }
+
+        /// <summary>
+        /// Opens a stream writer and returns without disposing it.
+        /// Once this method returns, the writer and instruction are only
+        /// reachable through the GC — no live references remain on the stack.
+        /// </summary>
+        private IEnumerator OpenAndLeakWriter(TestRoomContext context)
+        {
+            var streamInstruction = context.Rooms[0].LocalParticipant.StreamText("gc-test-topic");
+            yield return streamInstruction;
+            Assert.IsFalse(streamInstruction.IsError, "StreamText open failed");
+            Assert.IsNotNull(streamInstruction.Writer, "Writer should not be null");
+            // Method returns — streamInstruction and its Writer become unreachable
+        }
+    }
+}

--- a/Tests/PlayMode/FfiHandleDisposalTests.cs
+++ b/Tests/PlayMode/FfiHandleDisposalTests.cs
@@ -23,7 +23,7 @@ namespace LiveKit.PlayModeTests
         // The FfiHandle.ReleaseHandle fix marshals the Rust drop to the main thread via
         // SynchronizationContext, but in batchmode on Linux the context may not be
         // available, so the GC finalizer still calls FfiDropHandle on a non-Tokio thread.
-        [UnityTest, Category("E2E"), Ignore("Known issue")]
+        [UnityTest, Category("E2E")]
         public IEnumerator StreamWriter_LeakedHandle_DoesNotCrashOnGC()
         {
             LogAssert.ignoreFailingMessages = true;

--- a/Tests/PlayMode/FfiHandleDisposalTests.cs
+++ b/Tests/PlayMode/FfiHandleDisposalTests.cs
@@ -19,7 +19,11 @@ namespace LiveKit.PlayModeTests
         /// After the fix:  The handle drop is marshaled to the main thread and
         ///                 Unity continues running normally.
         /// </summary>
-        [UnityTest, Category("E2E")]
+        // Known issue: crashes Unity on Linux CI (batchmode) with exit code 134.
+        // The FfiHandle.ReleaseHandle fix marshals the Rust drop to the main thread via
+        // SynchronizationContext, but in batchmode on Linux the context may not be
+        // available, so the GC finalizer still calls FfiDropHandle on a non-Tokio thread.
+        [UnityTest, Category("E2E"), Ignore("Known issue")]
         public IEnumerator StreamWriter_LeakedHandle_DoesNotCrashOnGC()
         {
             LogAssert.ignoreFailingMessages = true;

--- a/Tests/PlayMode/FfiHandleDisposalTests.cs.meta
+++ b/Tests/PlayMode/FfiHandleDisposalTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ddfae6d195ad481eb21d674bfab1831
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/ParticipantMetadataTests.cs
+++ b/Tests/PlayMode/ParticipantMetadataTests.cs
@@ -1,0 +1,116 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using LiveKit.PlayModeTests.Utils;
+
+namespace LiveKit.PlayModeTests
+{
+    public class ParticipantMetadataTests
+    {
+        [UnityTest, Category("E2E")]
+        public IEnumerator SetMetadata_UpdatesLocalAndTriggersRemoteEvent()
+        {
+            var first = TestRoomContext.ConnectionOptions.Default;
+            first.Identity = "first";
+            first.CanUpdateOwnMetadata = true;
+            var second = TestRoomContext.ConnectionOptions.Default;
+            second.Identity = "second";
+
+            using var context = new TestRoomContext(new[] { first, second });
+
+            string receivedMetadata = null;
+            var metadataExpectation = new Expectation(timeoutSeconds: 10f);
+            context.Rooms[1].ParticipantMetadataChanged += (participant) =>
+            {
+                if (participant.Identity == first.Identity)
+                {
+                    receivedMetadata = participant.Metadata;
+                    metadataExpectation.Fulfill();
+                }
+            };
+
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var setInstruction = context.Rooms[0].LocalParticipant.SetMetadata("new-metadata");
+            yield return setInstruction;
+            Assert.IsFalse(setInstruction.IsError, "SetMetadata failed");
+
+            yield return metadataExpectation.Wait();
+            Assert.IsNull(metadataExpectation.Error, metadataExpectation.Error);
+            Assert.AreEqual("new-metadata", receivedMetadata);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator SetName_UpdatesLocalAndTriggersRemoteEvent()
+        {
+            var first = TestRoomContext.ConnectionOptions.Default;
+            first.Identity = "first";
+            first.CanUpdateOwnMetadata = true;
+            var second = TestRoomContext.ConnectionOptions.Default;
+            second.Identity = "second";
+
+            using var context = new TestRoomContext(new[] { first, second });
+
+            string receivedName = null;
+            var nameExpectation = new Expectation(timeoutSeconds: 10f);
+            context.Rooms[1].ParticipantNameChanged += (participant) =>
+            {
+                if (participant.Identity == first.Identity)
+                {
+                    receivedName = participant.Name;
+                    nameExpectation.Fulfill();
+                }
+            };
+
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var setInstruction = context.Rooms[0].LocalParticipant.SetName("new-display-name");
+            yield return setInstruction;
+            Assert.IsFalse(setInstruction.IsError, "SetName failed");
+
+            yield return nameExpectation.Wait();
+            Assert.IsNull(nameExpectation.Error, nameExpectation.Error);
+            Assert.AreEqual("new-display-name", receivedName);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator SetAttributes_UpdatesLocalAndTriggersRemoteEvent()
+        {
+            var first = TestRoomContext.ConnectionOptions.Default;
+            first.Identity = "first";
+            first.CanUpdateOwnMetadata = true;
+            var second = TestRoomContext.ConnectionOptions.Default;
+            second.Identity = "second";
+
+            using var context = new TestRoomContext(new[] { first, second });
+
+            var attributesExpectation = new Expectation(timeoutSeconds: 10f);
+            IDictionary<string, string> receivedAttributes = null;
+            context.Rooms[1].ParticipantAttributesChanged += (participant) =>
+            {
+                if (participant.Identity == first.Identity)
+                {
+                    receivedAttributes = new Dictionary<string, string>(participant.Attributes);
+                    attributesExpectation.Fulfill();
+                }
+            };
+
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var attrs = new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } };
+            var setInstruction = context.Rooms[0].LocalParticipant.SetAttributes(attrs);
+            yield return setInstruction;
+            Assert.IsFalse(setInstruction.IsError, "SetAttributes failed");
+
+            yield return attributesExpectation.Wait();
+            Assert.IsNull(attributesExpectation.Error, attributesExpectation.Error);
+            Assert.IsNotNull(receivedAttributes);
+            Assert.AreEqual("value1", receivedAttributes["key1"]);
+            Assert.AreEqual("value2", receivedAttributes["key2"]);
+        }
+    }
+}

--- a/Tests/PlayMode/ParticipantMetadataTests.cs.meta
+++ b/Tests/PlayMode/ParticipantMetadataTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d47b563c4f9294ad0aa84402a2150b3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/RpcTests.cs
+++ b/Tests/PlayMode/RpcTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using LiveKit.PlayModeTests.Utils;
+
+namespace LiveKit.PlayModeTests
+{
+    public class RpcTests
+    {
+        [UnityTest, Category("E2E"), Order(0)]
+        public IEnumerator RegisterRpcMethod_AndPerformRpc_ReturnsResponse()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            var caller = TestRoomContext.ConnectionOptions.Default;
+            caller.Identity = "rpc-caller-1";
+            var responder = TestRoomContext.ConnectionOptions.Default;
+            responder.Identity = "rpc-responder-1";
+
+            using var context = new TestRoomContext(new[] { caller, responder });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            context.Rooms[1].LocalParticipant.RegisterRpcMethod("echo", async (data) =>
+            {
+                return $"echo:{data.Payload}";
+            });
+
+            var rpcInstruction = context.Rooms[0].LocalParticipant.PerformRpc(new PerformRpcParams
+            {
+                DestinationIdentity = responder.Identity,
+                Method = "echo",
+                Payload = "hello"
+            });
+            yield return rpcInstruction;
+
+            Assert.IsFalse(rpcInstruction.IsError, rpcInstruction.Error?.Message);
+            Assert.AreEqual("echo:hello", rpcInstruction.Payload);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator PerformRpc_HandlerThrowsRpcError_PropagatesError()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            var caller = TestRoomContext.ConnectionOptions.Default;
+            caller.Identity = "rpc-caller-2";
+            var responder = TestRoomContext.ConnectionOptions.Default;
+            responder.Identity = "rpc-responder-2";
+
+            using var context = new TestRoomContext(new[] { caller, responder });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            context.Rooms[1].LocalParticipant.RegisterRpcMethod("throw-rpc", async (data) =>
+            {
+                throw new RpcError(42, "custom error", "custom data");
+            });
+
+            var rpcInstruction = context.Rooms[0].LocalParticipant.PerformRpc(new PerformRpcParams
+            {
+                DestinationIdentity = responder.Identity,
+                Method = "throw-rpc",
+                Payload = "trigger-error"
+            });
+            yield return rpcInstruction;
+
+            Assert.IsTrue(rpcInstruction.IsError);
+            Assert.AreEqual((uint)42, rpcInstruction.Error.Code);
+            Assert.AreEqual("custom data", rpcInstruction.Error.RpcData);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator PerformRpc_HandlerThrowsGenericException_ReturnsApplicationError()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            var caller = TestRoomContext.ConnectionOptions.Default;
+            caller.Identity = "rpc-caller-3";
+            var responder = TestRoomContext.ConnectionOptions.Default;
+            responder.Identity = "rpc-responder-3";
+
+            using var context = new TestRoomContext(new[] { caller, responder });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            context.Rooms[1].LocalParticipant.RegisterRpcMethod("throw-generic", async (data) =>
+            {
+                throw new InvalidOperationException("something went wrong");
+            });
+
+            var rpcInstruction = context.Rooms[0].LocalParticipant.PerformRpc(new PerformRpcParams
+            {
+                DestinationIdentity = responder.Identity,
+                Method = "throw-generic",
+                Payload = "trigger-generic-error"
+            });
+            yield return rpcInstruction;
+
+            Assert.IsTrue(rpcInstruction.IsError);
+            Assert.AreEqual((uint)RpcError.ErrorCode.APPLICATION_ERROR, rpcInstruction.Error.Code);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator PerformRpc_UnregisteredMethod_ReturnsUnsupportedMethod()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            var caller = TestRoomContext.ConnectionOptions.Default;
+            caller.Identity = "rpc-caller-4";
+            var responder = TestRoomContext.ConnectionOptions.Default;
+            responder.Identity = "rpc-responder-4";
+
+            using var context = new TestRoomContext(new[] { caller, responder });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var rpcInstruction = context.Rooms[0].LocalParticipant.PerformRpc(new PerformRpcParams
+            {
+                DestinationIdentity = responder.Identity,
+                Method = "nonexistent-method",
+                Payload = ""
+            });
+            yield return rpcInstruction;
+
+            Assert.IsTrue(rpcInstruction.IsError);
+            Assert.AreEqual((uint)RpcError.ErrorCode.UNSUPPORTED_METHOD, rpcInstruction.Error.Code);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator UnregisterRpcMethod_ThenPerformRpc_ReturnsUnsupportedMethod()
+        {
+            LogAssert.ignoreFailingMessages = true;
+
+            var caller = TestRoomContext.ConnectionOptions.Default;
+            caller.Identity = "rpc-caller-5";
+            var responder = TestRoomContext.ConnectionOptions.Default;
+            responder.Identity = "rpc-responder-5";
+
+            using var context = new TestRoomContext(new[] { caller, responder });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            context.Rooms[1].LocalParticipant.RegisterRpcMethod("unreg-test", async (data) =>
+            {
+                return "should not reach here";
+            });
+            context.Rooms[1].LocalParticipant.UnregisterRpcMethod("unreg-test");
+
+            var rpcInstruction = context.Rooms[0].LocalParticipant.PerformRpc(new PerformRpcParams
+            {
+                DestinationIdentity = responder.Identity,
+                Method = "unreg-test",
+                Payload = ""
+            });
+            yield return rpcInstruction;
+
+            Assert.IsTrue(rpcInstruction.IsError);
+            Assert.AreEqual((uint)RpcError.ErrorCode.UNSUPPORTED_METHOD, rpcInstruction.Error.Code);
+        }
+    }
+}

--- a/Tests/PlayMode/RpcTests.cs.meta
+++ b/Tests/PlayMode/RpcTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80e440ffeedbc45da89f431c5c9b2f67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/TextStreamTests.cs
+++ b/Tests/PlayMode/TextStreamTests.cs
@@ -173,5 +173,58 @@ namespace LiveKit.PlayModeTests
             Assert.IsNull(receivedExpectation.Error, receivedExpectation.Error);
             Assert.AreEqual("Hello World", receivedText);
         }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator StreamText_CloseWithoutReason_Succeeds()
+        {
+            var sender = TestRoomContext.ConnectionOptions.Default;
+            sender.Identity = "sender";
+            var receiver = TestRoomContext.ConnectionOptions.Default;
+            receiver.Identity = "receiver";
+
+            using var context = new TestRoomContext(new[] { sender, receiver });
+
+            string receivedText = null;
+            var receivedExpectation = new Expectation(timeoutSeconds: 10f);
+
+            context.Rooms[1].RegisterTextStreamHandler("close-topic", (reader, identity) =>
+            {
+                var readAll = reader.ReadAll();
+                System.Threading.Tasks.Task.Run(async () =>
+                {
+                    while (!readAll.IsDone) await System.Threading.Tasks.Task.Delay(10);
+                    if (!readAll.IsError)
+                    {
+                        receivedText = readAll.Text;
+                        receivedExpectation.Fulfill();
+                    }
+                    else receivedExpectation.Fail("ReadAll failed");
+                });
+            });
+
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var streamInstruction = context.Rooms[0].LocalParticipant.StreamText("close-topic");
+            yield return streamInstruction;
+            Assert.IsFalse(streamInstruction.IsError, "StreamText open failed");
+
+            var writer = streamInstruction.Writer;
+
+            var write = writer.Write("test");
+            yield return write;
+            Assert.IsFalse(write.IsError, "Write failed");
+
+            // Call Close() with no arguments — this is the bug regression test.
+            // Before fix: throws ArgumentNullException because default reason=null
+            // hits ProtoPreconditions.CheckNotNull in the generated proto setter.
+            var close = writer.Close();
+            yield return close;
+            Assert.IsFalse(close.IsError, "Close without reason failed");
+
+            yield return receivedExpectation.Wait();
+            Assert.IsNull(receivedExpectation.Error, receivedExpectation.Error);
+            Assert.AreEqual("test", receivedText);
+        }
     }
 }

--- a/Tests/PlayMode/TextStreamTests.cs
+++ b/Tests/PlayMode/TextStreamTests.cs
@@ -1,0 +1,177 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using LiveKit.PlayModeTests.Utils;
+
+namespace LiveKit.PlayModeTests
+{
+    public class TextStreamTests
+    {
+        [UnityTest, Category("E2E")]
+        public IEnumerator SendText_ReceivedByHandler_ContentMatches()
+        {
+            var sender = TestRoomContext.ConnectionOptions.Default;
+            sender.Identity = "sender";
+            var receiver = TestRoomContext.ConnectionOptions.Default;
+            receiver.Identity = "receiver";
+
+            using var context = new TestRoomContext(new[] { sender, receiver });
+
+            string receivedText = null;
+            string receivedIdentity = null;
+            var receivedExpectation = new Expectation(timeoutSeconds: 10f);
+
+            context.Rooms[1].RegisterTextStreamHandler("test-topic", (reader, identity) =>
+            {
+                receivedIdentity = identity;
+                var readAll = reader.ReadAll();
+                System.Threading.Tasks.Task.Run(async () =>
+                {
+                    while (!readAll.IsDone)
+                        await System.Threading.Tasks.Task.Delay(10);
+
+                    if (!readAll.IsError)
+                    {
+                        receivedText = readAll.Text;
+                        receivedExpectation.Fulfill();
+                    }
+                    else
+                    {
+                        receivedExpectation.Fail("ReadAll failed");
+                    }
+                });
+            });
+
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var sendInstruction = context.Rooms[0].LocalParticipant.SendText("hello world", "test-topic");
+            yield return sendInstruction;
+            Assert.IsFalse(sendInstruction.IsError, "SendText failed");
+
+            yield return receivedExpectation.Wait();
+            Assert.IsNull(receivedExpectation.Error, receivedExpectation.Error);
+            Assert.AreEqual("hello world", receivedText);
+            Assert.AreEqual(sender.Identity, receivedIdentity);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator SendText_WithTopic_DispatchesToCorrectHandler()
+        {
+            var sender = TestRoomContext.ConnectionOptions.Default;
+            sender.Identity = "sender";
+            var receiver = TestRoomContext.ConnectionOptions.Default;
+            receiver.Identity = "receiver";
+
+            using var context = new TestRoomContext(new[] { sender, receiver });
+
+            string topicAText = null;
+            string topicBText = null;
+            var topicAExpectation = new Expectation(timeoutSeconds: 10f);
+            var topicBExpectation = new Expectation(timeoutSeconds: 10f);
+
+            context.Rooms[1].RegisterTextStreamHandler("topic-a", (reader, identity) =>
+            {
+                var readAll = reader.ReadAll();
+                System.Threading.Tasks.Task.Run(async () =>
+                {
+                    while (!readAll.IsDone) await System.Threading.Tasks.Task.Delay(10);
+                    if (!readAll.IsError)
+                    {
+                        topicAText = readAll.Text;
+                        topicAExpectation.Fulfill();
+                    }
+                    else topicAExpectation.Fail("ReadAll failed for topic-a");
+                });
+            });
+
+            context.Rooms[1].RegisterTextStreamHandler("topic-b", (reader, identity) =>
+            {
+                var readAll = reader.ReadAll();
+                System.Threading.Tasks.Task.Run(async () =>
+                {
+                    while (!readAll.IsDone) await System.Threading.Tasks.Task.Delay(10);
+                    if (!readAll.IsError)
+                    {
+                        topicBText = readAll.Text;
+                        topicBExpectation.Fulfill();
+                    }
+                    else topicBExpectation.Fail("ReadAll failed for topic-b");
+                });
+            });
+
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var sendA = context.Rooms[0].LocalParticipant.SendText("message-a", "topic-a");
+            yield return sendA;
+            Assert.IsFalse(sendA.IsError, "SendText to topic-a failed");
+
+            var sendB = context.Rooms[0].LocalParticipant.SendText("message-b", "topic-b");
+            yield return sendB;
+            Assert.IsFalse(sendB.IsError, "SendText to topic-b failed");
+
+            yield return topicAExpectation.Wait();
+            Assert.IsNull(topicAExpectation.Error, topicAExpectation.Error);
+            Assert.AreEqual("message-a", topicAText);
+
+            yield return topicBExpectation.Wait();
+            Assert.IsNull(topicBExpectation.Error, topicBExpectation.Error);
+            Assert.AreEqual("message-b", topicBText);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator StreamText_WriteAndClose_ReceivedViaReadAll()
+        {
+            var sender = TestRoomContext.ConnectionOptions.Default;
+            sender.Identity = "sender";
+            var receiver = TestRoomContext.ConnectionOptions.Default;
+            receiver.Identity = "receiver";
+
+            using var context = new TestRoomContext(new[] { sender, receiver });
+
+            string receivedText = null;
+            var receivedExpectation = new Expectation(timeoutSeconds: 10f);
+
+            context.Rooms[1].RegisterTextStreamHandler("stream-topic", (reader, identity) =>
+            {
+                var readAll = reader.ReadAll();
+                System.Threading.Tasks.Task.Run(async () =>
+                {
+                    while (!readAll.IsDone) await System.Threading.Tasks.Task.Delay(10);
+                    if (!readAll.IsError)
+                    {
+                        receivedText = readAll.Text;
+                        receivedExpectation.Fulfill();
+                    }
+                    else receivedExpectation.Fail("ReadAll failed");
+                });
+            });
+
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var streamInstruction = context.Rooms[0].LocalParticipant.StreamText("stream-topic");
+            yield return streamInstruction;
+            Assert.IsFalse(streamInstruction.IsError, "StreamText open failed");
+
+            var writer = streamInstruction.Writer;
+
+            var write1 = writer.Write("Hello ");
+            yield return write1;
+            Assert.IsFalse(write1.IsError, "Write chunk 1 failed");
+
+            var write2 = writer.Write("World");
+            yield return write2;
+            Assert.IsFalse(write2.IsError, "Write chunk 2 failed");
+
+            var close = writer.Close("");
+            yield return close;
+            Assert.IsFalse(close.IsError, "Close failed");
+
+            yield return receivedExpectation.Wait();
+            Assert.IsNull(receivedExpectation.Error, receivedExpectation.Error);
+            Assert.AreEqual("Hello World", receivedText);
+        }
+    }
+}

--- a/Tests/PlayMode/TextStreamTests.cs
+++ b/Tests/PlayMode/TextStreamTests.cs
@@ -174,7 +174,7 @@ namespace LiveKit.PlayModeTests
             Assert.AreEqual("Hello World", receivedText);
         }
 
-        [UnityTest, Category("E2E"), Ignore("Known issue: CLT-2774")]
+        [UnityTest, Category("E2E")]
         public IEnumerator StreamText_CloseWithoutReason_Succeeds()
         {
             var sender = TestRoomContext.ConnectionOptions.Default;

--- a/Tests/PlayMode/TextStreamTests.cs
+++ b/Tests/PlayMode/TextStreamTests.cs
@@ -174,7 +174,7 @@ namespace LiveKit.PlayModeTests
             Assert.AreEqual("Hello World", receivedText);
         }
 
-        [UnityTest, Category("E2E")]
+        [UnityTest, Category("E2E"), Ignore("Known issue: CLT-2774")]
         public IEnumerator StreamText_CloseWithoutReason_Succeeds()
         {
             var sender = TestRoomContext.ConnectionOptions.Default;

--- a/Tests/PlayMode/TextStreamTests.cs.meta
+++ b/Tests/PlayMode/TextStreamTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 380d50e0aa1c0454a8c12d5949dfc28d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Background

Bug: Calling TextStreamWriter.Close() or ByteStreamWriter.Close() with no arguments throws System.ArgumentNullException: Value cannot be null. Parameter name: value. 

The exception originates in the generated protobuf setter TextStreamWriterCloseRequest.set_Reason (and its byte-stream equivalent), which calls ProtoPreconditions.CheckNotNull() and rejects the null value produced by the default parameter. 

Every caller that uses the documented parameterless overload of Close() crashes immediately, making this code path unusable in its current form. 

### Changes

- Fill field with `""` instead of `null`