### PR TITLE
CI: add build-ffi job if rust sdk changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,55 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  build-ffi:
+    name: Rebuild FFI (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      rebuilt: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+          submodules: recursive
+          fetch-depth: 0
+      - name: Check for Rust submodule changes
+        id: check
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
+          if git diff --name-only "origin/$BASE_REF"...HEAD | grep -q "^client-sdk-rust~" ; then
+            echo "Rust submodule has changes — will rebuild"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No Rust submodule changes — skipping build"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+      # Mirrors the Linux build from the upstream Rust SDK's ffi-builds.yml.
+      # If this breaks after an upstream change, check for updates there:
+      # https://github.com/livekit/client-sdk-rust/blob/main/.github/workflows/ffi-builds.yml
+      - name: Build liblivekit_ffi.so
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          docker run --rm -v $PWD/client-sdk-rust~:/workspace -w /workspace \
+            sameli/manylinux_2_28_x86_64_cuda_12.3 bash -c "\
+              export PATH=/root/.cargo/bin:\$PATH && \
+              yum install -y llvm llvm-libs lld clang protobuf-compiler && \
+              yum groupinstall -y 'Development Tools' && \
+              yum install -y openssl-devel libX11-devel mesa-libGL-devel libXext-devel && \
+              curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+              cd livekit-ffi && cargo build --release --target x86_64-unknown-linux-gnu"
+          sudo cp client-sdk-rust~/target/x86_64-unknown-linux-gnu/release/liblivekit_ffi.so \
+             Runtime/Plugins/ffi-linux-x86_64/liblivekit_ffi.so
+      - name: Upload rebuilt library
+        if: steps.check.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffi-linux-x86_64
+          path: Runtime/Plugins/ffi-linux-x86_64/liblivekit_ffi.so
   test:
     name: Test (${{ matrix.unityVersion }})
+    needs: build-ffi
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -27,6 +74,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+      - name: Download rebuilt FFI library
+        if: needs.build-ffi.outputs.rebuilt == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ffi-linux-x86_64
+          path: Runtime/Plugins/ffi-linux-x86_64/
       # Required when using package mode, see open issue:
       # https://github.com/game-ci/unity-test-runner/issues/223
       - name: Move Into Subdirectory


### PR DESCRIPTION
## Summary
- Add a Linux-only `build-ffi` job that rebuilds `liblivekit_ffi.so` from the `client-sdk-rust~` submodule when the PR touches it (mirrors the upstream Rust SDK's `ffi-builds.yml` Linux build)
- Upload the rebuilt `.so` as an artifact; the `test` job downloads it before running so tests exercise the current submodule rather than the LFS-tracked binary
- When the submodule is untouched, the build step is skipped and tests use the committed binary as before

See the mechanism working here:
- Without Rust change: job is skipped - test fails: 
  - https://github.com/livekit/client-sdk-unity/actions/runs/24449650951/job/71435050881
- With Rust change: job is executed - test is fixed: 
  - https://github.com/livekit/client-sdk-unity/actions/runs/24449863960/job/71436846364