### PR TITLE
Fix writer close error

### DIFF
--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -698,7 +698,7 @@ namespace LiveKit
         /// A <see cref="CloseInstruction"/> that completes when the close operation is complete or errors.
         /// Check <see cref="CloseInstruction.Error"/> to see if the operation was successful.
         /// </returns>
-        public CloseInstruction Close(string reason = null)
+        public CloseInstruction Close(string reason = "")
         {
             if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<TextStreamWriterCloseRequest>();
@@ -787,7 +787,7 @@ namespace LiveKit
         /// <returns>
         /// A <see cref="CloseInstruction"/> that completes when the close operation is complete or errors.
         /// </returns>
-        public CloseInstruction Close(string reason = null)
+        public CloseInstruction Close(string reason = "")
         {
             if (_disposed) throw new ObjectDisposedException(GetType().FullName);
             using var request = FFIBridge.Instance.NewRequest<ByteStreamWriterCloseRequest>();

--- a/Tests/PlayMode/TextStreamTests.cs
+++ b/Tests/PlayMode/TextStreamTests.cs
@@ -174,7 +174,7 @@ namespace LiveKit.PlayModeTests
             Assert.AreEqual("Hello World", receivedText);
         }
 
-        [UnityTest, Category("E2E"), Ignore("Known issue: CLT-2774")]
+        [UnityTest, Category("E2E")]
         public IEnumerator StreamText_CloseWithoutReason_Succeeds()
         {
             var sender = TestRoomContext.ConnectionOptions.Default;


### PR DESCRIPTION
### Background

Bug: Calling TextStreamWriter.Close() or ByteStreamWriter.Close() with no arguments throws System.ArgumentNullException: Value cannot be null. Parameter name: value. 

The exception originates in the generated protobuf setter TextStreamWriterCloseRequest.set_Reason (and its byte-stream equivalent), which calls ProtoPreconditions.CheckNotNull() and rejects the null value produced by the default parameter. 

Every caller that uses the documented parameterless overload of Close() crashes immediately, making this code path unusable in its current form. 

### Changes

- Fill field with `""` instead of `null`