### PR TITLE
Batch 1 Bugfix: NullReferenceException in RTCConfiguration.ToProto and IceServer.ToProto

### DIFF
--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -33,7 +33,8 @@ namespace LiveKit
             var proto = new Proto.IceServer();
             proto.Username = Username;
             proto.Password = Password;
-            proto.Urls.AddRange(Urls);
+            if (Urls != null)
+                proto.Urls.AddRange(Urls);
 
             return proto;
         }
@@ -72,9 +73,12 @@ namespace LiveKit
                     break;
             }
 
-            foreach (var item in IceServers)
+            if (IceServers != null)
             {
-                proto.IceServers.Add(item.ToProto());
+                foreach (var item in IceServers)
+                {
+                    proto.IceServers.Add(item.ToProto());
+                }
             }
 
             return proto;

--- a/Tests/EditMode/LiveKit.EditModeTests.asmdef
+++ b/Tests/EditMode/LiveKit.EditModeTests.asmdef
@@ -13,7 +13,8 @@
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll"
+        "nunit.framework.dll",
+        "Google.Protobuf.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [

--- a/Tests/EditMode/RoomOptionsTests.cs
+++ b/Tests/EditMode/RoomOptionsTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+
+namespace LiveKit.EditModeTests
+{
+    public class RoomOptionsTests
+    {
+        [Test]
+        public void RTCConfiguration_ToProto_DefaultInstance_DoesNotThrow()
+        {
+            var config = new RTCConfiguration();
+            Assert.DoesNotThrow(() => config.ToProto());
+        }
+
+        [Test]
+        public void IceServer_ToProto_WithAllFieldsSet_Succeeds()
+        {
+            var server = new IceServer
+            {
+                Urls = new[] { "stun:stun.example.com:3478" },
+                Username = "user",
+                Password = "pass"
+            };
+
+            var proto = server.ToProto();
+
+            Assert.AreEqual("user", proto.Username);
+            Assert.AreEqual("pass", proto.Password);
+            Assert.AreEqual(1, proto.Urls.Count);
+            Assert.AreEqual("stun:stun.example.com:3478", proto.Urls[0]);
+        }
+
+        [Test]
+        public void IceServer_ToProto_WithNullUrls_DoesNotThrow()
+        {
+            var server = new IceServer { Username = "u", Password = "p" };
+            Assert.DoesNotThrow(() => server.ToProto());
+        }
+    }
+}

--- a/Tests/EditMode/RoomOptionsTests.cs.meta
+++ b/Tests/EditMode/RoomOptionsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d83fa28ae6244f298a06ad3c590de1b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
Default-constructed instances of \`RTCConfiguration\` and \`IceServer\` threw on \`ToProto()\` because their array fields (\`IceServers\`, \`Urls\`) have no initializer and the proto serialization path iterated them without a null guard.

- \`RTCConfiguration.ToProto()\` → \`NullReferenceException\` at \`Room.cs:75\` (foreach over null array)
- \`IceServer.ToProto()\` → \`ArgumentNullException\` from \`Google.Protobuf.Collections.RepeatedField<string>.AddRange(null)\` at \`Room.cs:36\`

Both are now null-guarded. Adds three regression tests in \`Tests/EditMode/RoomOptionsTests.cs\`:
- \`RTCConfiguration_ToProto_DefaultInstance_DoesNotThrow\`
- \`IceServer_ToProto_WithNullUrls_DoesNotThrow\`
- \`IceServer_ToProto_WithAllFieldsSet_Succeeds\` (happy path, validates serialized output)

\`Tests/EditMode/LiveKit.EditModeTests.asmdef\` now references \`Google.Protobuf.dll\` so the happy-path test can inspect the \`RepeatedField<string>\` the proto exposes.

## Test plan
- [x] \`./Scripts~/run_unity.sh test -m EditMode -f LiveKit.EditModeTests.RoomOptionsTests\` → 3/3 pass
- [x] Full EditMode regression: \`./Scripts~/run_unity.sh test -m EditMode\` → 35 passed, 2 skipped (pre-existing), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)