### PR TITLE
Batch 2 Bugfix: IRemoteTrack.SetEnabled: dispatch EnableRemoteTrackRequest over FFI

### DIFF
--- a/Runtime/Scripts/Internal/FFIClients/FfiRequestExtensions.cs
+++ b/Runtime/Scripts/Internal/FFIClients/FfiRequestExtensions.cs
@@ -152,6 +152,9 @@ namespace LiveKit.Internal.FFIClients
                 case LocalTrackMuteRequest localTrackMuteRequest:
                     ffiRequest.LocalTrackMute = localTrackMuteRequest;
                     break;
+                case EnableRemoteTrackRequest enableRemoteTrackRequest:
+                    ffiRequest.EnableRemoteTrack = enableRemoteTrackRequest;
+                    break;
                 case E2eeRequest e2EeRequest:
                     ffiRequest.E2Ee = e2EeRequest;
                     break;

--- a/Tests/PlayMode/RemoteTrackEnabledRegressionTests.cs
+++ b/Tests/PlayMode/RemoteTrackEnabledRegressionTests.cs
@@ -6,13 +6,11 @@ using UnityEngine.TestTools;
 
 namespace LiveKit.PlayModeTests
 {
-    /// <summary>
-    /// Regression test for IRemoteTrack.SetEnabled: EnableRemoteTrackRequest was missing
-    /// from FfiRequestExtensions.Inject, so every call threw "Unknown request type".
+    /// <summary>    
     /// This test publishes an audio track from a second room and exercises the FFI
     /// round-trip on the subscriber side.
     /// </summary>
-    public class RemoteTrackEnabledRegressionTests
+    public class RemoteTrackEnabledTests
     {
         [UnityTest, Category("E2E")]
         public IEnumerator RemoteTrack_SetEnabled_FalseAndTrue_DoesNotThrow()

--- a/Tests/PlayMode/RemoteTrackEnabledRegressionTests.cs
+++ b/Tests/PlayMode/RemoteTrackEnabledRegressionTests.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using LiveKit.PlayModeTests.Utils;
+using LiveKit.Proto;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace LiveKit.PlayModeTests
+{
+    /// <summary>
+    /// Regression test for IRemoteTrack.SetEnabled: EnableRemoteTrackRequest was missing
+    /// from FfiRequestExtensions.Inject, so every call threw "Unknown request type".
+    /// This test publishes an audio track from a second room and exercises the FFI
+    /// round-trip on the subscriber side.
+    /// </summary>
+    public class RemoteTrackEnabledRegressionTests
+    {
+        [UnityTest, Category("E2E")]
+        public IEnumerator RemoteTrack_SetEnabled_FalseAndTrue_DoesNotThrow()
+        {
+            var publisher = TestRoomContext.ConnectionOptions.Default;
+            publisher.Identity = "enable-remote-publisher";
+            var subscriber = TestRoomContext.ConnectionOptions.Default;
+            subscriber.Identity = "enable-remote-subscriber";
+
+            using var context = new TestRoomContext(new[] { publisher, subscriber });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var publisherRoom = context.Rooms[0];
+            var subscriberRoom = context.Rooms[1];
+
+            using var source = new SineWaveAudioSource();
+            var localTrack = LocalAudioTrack.CreateAudioTrack("enable-remote-audio", source, publisherRoom);
+
+            var subscribedExp = new Expectation(timeoutSeconds: 10f);
+            IRemoteTrack receivedRemoteTrack = null;
+            subscriberRoom.TrackSubscribed += (remoteTrack, publication, participant) =>
+            {
+                receivedRemoteTrack = remoteTrack;
+                subscribedExp.Fulfill();
+            };
+
+            var pub = publisherRoom.LocalParticipant.PublishTrack(
+                localTrack,
+                new TrackPublishOptions { Source = TrackSource.SourceMicrophone });
+            yield return pub;
+            Assert.IsFalse(pub.IsError);
+
+            source.Start();
+            yield return subscribedExp.Wait();
+            Assert.IsNull(subscribedExp.Error);
+            Assert.IsNotNull(receivedRemoteTrack);
+
+            Assert.DoesNotThrow(() => receivedRemoteTrack.SetEnabled(false));
+            Assert.DoesNotThrow(() => receivedRemoteTrack.SetEnabled(true));
+        }
+    }
+}

--- a/Tests/PlayMode/RemoteTrackEnabledRegressionTests.cs.meta
+++ b/Tests/PlayMode/RemoteTrackEnabledRegressionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2303181ca4ca4c6888a14b77b687aae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/Utils/SineWaveAudioSource.cs
+++ b/Tests/PlayMode/Utils/SineWaveAudioSource.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading;
+
+namespace LiveKit.PlayModeTests.Utils
+{
+    /// <summary>
+    /// Test-only <see cref="RtcAudioSource"/> that emits a deterministic sine wave.
+    /// Uses a <see cref="Timer"/> to push 20ms PCM frames via the base class's
+    /// FFI capture path; avoids the Unity audio subsystem entirely so it works in
+    /// batch-mode test runners.
+    /// </summary>
+    public sealed class SineWaveAudioSource : RtcAudioSource
+    {
+        public override event Action<float[], int, int> AudioRead;
+
+        private const int FrameDurationMs = 20;
+
+        private readonly int _channels;
+        private readonly int _sampleRate;
+        private readonly int _samplesPerFrame;
+        private readonly double _phaseIncrement;
+        private readonly float _amplitude;
+
+        private Timer _timer;
+        private double _phase;
+        private bool _running;
+        private bool _disposed;
+
+        public SineWaveAudioSource(
+            int channels = 2,
+            int sampleRate = 48000,
+            double frequencyHz = 440.0,
+            float amplitude = 0.1f)
+            : base(channels, RtcAudioSourceType.AudioSourceCustom)
+        {
+            _channels = channels;
+            _sampleRate = sampleRate;
+            _samplesPerFrame = sampleRate * FrameDurationMs / 1000;
+            _phaseIncrement = 2.0 * Math.PI * frequencyHz / sampleRate;
+            _amplitude = amplitude;
+        }
+
+        public override void Start()
+        {
+            base.Start();
+            if (_running || _disposed) return;
+            _running = true;
+            _timer = new Timer(PumpFrame, null, 0, FrameDurationMs);
+        }
+
+        public override void Stop()
+        {
+            base.Stop();
+            if (!_running) return;
+            _running = false;
+            _timer?.Dispose();
+            _timer = null;
+        }
+
+        private void PumpFrame(object _)
+        {
+            if (!_running || _disposed) return;
+            try
+            {
+                var buffer = new float[_samplesPerFrame * _channels];
+                for (int i = 0; i < _samplesPerFrame; i++)
+                {
+                    var sample = (float)(_amplitude * Math.Sin(_phase));
+                    _phase += _phaseIncrement;
+                    if (_phase >= 2.0 * Math.PI) _phase -= 2.0 * Math.PI;
+                    for (int c = 0; c < _channels; c++)
+                        buffer[i * _channels + c] = sample;
+                }
+                AudioRead?.Invoke(buffer, _channels, _sampleRate);
+            }
+            catch
+            {
+                // Timer fires independently of FFI lifecycle; swallow errors during teardown.
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed && disposing) Stop();
+            _disposed = true;
+            base.Dispose(disposing);
+        }
+
+        ~SineWaveAudioSource()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/Tests/PlayMode/Utils/SineWaveAudioSource.cs.meta
+++ b/Tests/PlayMode/Utils/SineWaveAudioSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c81150527ad774a9d8028f6cf7ebbaed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

\`IRemoteTrack.SetEnabled\` was completely non-functional:

\`\`\`
System.Exception: Unknown request type: LiveKit.Proto.EnableRemoteTrackRequest
  at LiveKit.Internal.FFIClients.FfiRequestExtensions.Inject[T] (...) in FfiRequestExtensions.cs:237
  at LiveKit.Internal.FFIClients.Requests.FfiRequestWrap\`1[T].Send () (...) in FfiRequestWrap.cs:59
  at LiveKit.IRemoteTrack.SetEnabled (System.Boolean enabled) (...) in Track.cs:59
\`\`\`

The proto field \`EnableRemoteTrack\` exists on \`FfiRequest\` but \`FfiRequestExtensions.Inject\`'s type switch had no case for \`EnableRemoteTrackRequest\`, so it fell through to \`default\` and threw. Adds the one missing case (matches the pattern used for all other request types).

## Regression test

\`Tests/PlayMode/RemoteTrackEnabledRegressionTests.cs\` — publishes an audio track from a second room, waits for \`TrackSubscribed\` on the subscriber, and calls \`SetEnabled(false)\` / \`SetEnabled(true)\`. Before the fix this test throws; after, it round-trips through FFI cleanly.

To make the test runnable in batch-mode CI (no real microphone), also introduces \`Tests/PlayMode/Utils/SineWaveAudioSource.cs\` — an \`RtcAudioSource\` subclass that pushes 20ms 48kHz PCM frames from a \`System.Threading.Timer\`, avoiding Unity's audio subsystem. Same utility is also part of an in-flight coverage expansion branch (\`max/more-tests/batch-2\`); merging either first is fine, content is identical.

## Test plan
- [x] \`./Scripts~/run_unity.sh test -m PlayMode -f LiveKit.PlayModeTests.RemoteTrackEnabledRegressionTests -n 5\` → 5/5 iterations pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)