### PR TITLE
Batch 3 Bugfix: Fix NullReferenceException in ByteStreamReader.WriteToFile default args

### DIFF
--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -393,8 +393,8 @@ namespace LiveKit
             using var request = FFIBridge.Instance.NewRequest<ByteStreamReaderWriteToFileRequest>();
             var writeToFileReq = request.request;
             writeToFileReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
-            writeToFileReq.Directory = directory;
-            writeToFileReq.NameOverride = nameOverride;
+            if (directory != null) writeToFileReq.Directory = directory;
+            if (nameOverride != null) writeToFileReq.NameOverride = nameOverride;
 
             var instruction = new WriteToFileInstruction(request.RequestAsyncId);
             using var response = request.Send();


### PR DESCRIPTION
## Summary

\`ByteStreamReader.WriteToFile(string directory = null, string nameOverride = null)\` threw \`ArgumentNullException\` from the generated protobuf setter when either argument was null — which is exactly the documented default:

\`\`\`
System.ArgumentNullException: Value cannot be null. Parameter name: value
  at Google.Protobuf.ProtoPreconditions.CheckNotNull[T] (...)
  at LiveKit.Proto.ByteStreamReaderWriteToFileRequest.set_NameOverride (...)
  at LiveKit.ByteStreamReader.WriteToFile (...) in DataStream.cs:397
\`\`\`

Same pattern the rest of the codebase already uses a null guard for (see \`StreamTextOptions.ToProto\`, \`StreamByteOptions.ToProto\` which each have a \`// TODO: these fields are optional, but the generated proto is not allowing null values\` comment and guard accordingly). The \`WriteToFile\` path just missed them.

## The fix

\`\`\`diff
-   writeToFileReq.Directory = directory;
-   writeToFileReq.NameOverride = nameOverride;
+   if (directory != null) writeToFileReq.Directory = directory;
+   if (nameOverride != null) writeToFileReq.NameOverride = nameOverride;
\`\`\`

## Validation

Ran a PlayMode E2E regression test locally (\`reader.WriteToFile(outDir)\` inside a byte-stream handler). Before the fix, the call threw synchronously. After, the call returns a \`WriteToFileInstruction\` and the handler proceeds normally.

## Why no regression test in this PR

Any PlayMode test that creates a \`ByteStreamReader\` and releases it through normal scope exit trips CLT-2773: the \`FfiHandle\` \`SafeHandle\` finalizer calls \`FfiDropHandle\` off the Tokio runtime, aborting the Unity process on teardown. NUnit reports the test as passing before the abort, but the script's exit code captures the abort and reports \"iteration failed.\" That's pre-existing, tracked separately, and explicitly out of scope for the current test-coverage workstream. Once CLT-2773 is resolved, a regression test can be added as a small follow-up.

## Related

There are two other similar null-safety issues in this file that I noticed while in here — \`ByteStreamWriter.Close(string reason = null)\` and \`TextStreamWriter.Close(string reason = null)\` both pass \`reason\` directly to their proto setters and would throw on \`Close()\` without args. Leaving those for a follow-up to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)