### PR TITLE
Batch 3: Stream lifecycle coverage (handler registration + SendFile)

### DIFF
--- a/Tests/EditMode/RoomStreamHandlerTests.cs
+++ b/Tests/EditMode/RoomStreamHandlerTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+
+namespace LiveKit.EditModeTests
+{
+    public class RoomStreamHandlerTests
+    {
+        [Test]
+        public void RegisterTextStreamHandler_DuplicateTopic_ThrowsStreamError()
+        {
+            var room = new Room();
+            room.RegisterTextStreamHandler("text-topic", (reader, identity) => { });
+
+            var ex = Assert.Throws<StreamError>(
+                () => room.RegisterTextStreamHandler("text-topic", (reader, identity) => { }));
+            StringAssert.Contains("text-topic", ex.Message);
+        }
+
+        [Test]
+        public void RegisterByteStreamHandler_DuplicateTopic_ThrowsStreamError()
+        {
+            var room = new Room();
+            room.RegisterByteStreamHandler("byte-topic", (reader, identity) => { });
+
+            var ex = Assert.Throws<StreamError>(
+                () => room.RegisterByteStreamHandler("byte-topic", (reader, identity) => { }));
+            StringAssert.Contains("byte-topic", ex.Message);
+        }
+
+        [Test]
+        public void UnregisterTextStreamHandler_AllowsReregistrationOfSameTopic()
+        {
+            var room = new Room();
+            room.RegisterTextStreamHandler("text-topic", (reader, identity) => { });
+            room.UnregisterTextStreamHandler("text-topic");
+
+            Assert.DoesNotThrow(
+                () => room.RegisterTextStreamHandler("text-topic", (reader, identity) => { }));
+        }
+
+        [Test]
+        public void UnregisterByteStreamHandler_AllowsReregistrationOfSameTopic()
+        {
+            var room = new Room();
+            room.RegisterByteStreamHandler("byte-topic", (reader, identity) => { });
+            room.UnregisterByteStreamHandler("byte-topic");
+
+            Assert.DoesNotThrow(
+                () => room.RegisterByteStreamHandler("byte-topic", (reader, identity) => { }));
+        }
+    }
+}

--- a/Tests/EditMode/RoomStreamHandlerTests.cs.meta
+++ b/Tests/EditMode/RoomStreamHandlerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bdf1c5f0507b4eeaaee5f835b5be5a2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/StreamLifecycleTests.cs
+++ b/Tests/PlayMode/StreamLifecycleTests.cs
@@ -1,0 +1,66 @@
+using System.Collections;
+using System.IO;
+using LiveKit.PlayModeTests.Utils;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace LiveKit.PlayModeTests
+{
+    public class StreamLifecycleTests
+    {
+        [UnityTest, Category("E2E")]
+        public IEnumerator SendFile_RecipientReceivesBytes()
+        {
+            var sender = TestRoomContext.ConnectionOptions.Default;
+            sender.Identity = "file-sender";
+            var receiver = TestRoomContext.ConnectionOptions.Default;
+            receiver.Identity = "file-receiver";
+
+            using var context = new TestRoomContext(new[] { sender, receiver });
+
+            const string topic = "file-topic";
+            var payload = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+            var tempFile = Path.GetTempFileName();
+            File.WriteAllBytes(tempFile, payload);
+
+            byte[] received = null;
+            var receivedExp = new Expectation(timeoutSeconds: 10f);
+
+            context.Rooms[1].RegisterByteStreamHandler(topic, (reader, identity) =>
+            {
+                var readAll = reader.ReadAll();
+                System.Threading.Tasks.Task.Run(async () =>
+                {
+                    while (!readAll.IsDone)
+                        await System.Threading.Tasks.Task.Delay(10);
+
+                    if (readAll.IsError)
+                        receivedExp.Fail("reader.ReadAll errored");
+                    else
+                    {
+                        received = readAll.Bytes;
+                        receivedExp.Fulfill();
+                    }
+                });
+            });
+
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            try
+            {
+                var sendInstruction = context.Rooms[0].LocalParticipant.SendFile(tempFile, topic);
+                yield return sendInstruction;
+                Assert.IsFalse(sendInstruction.IsError, "SendFile reported IsError");
+
+                yield return receivedExp.Wait();
+                Assert.IsNull(receivedExp.Error, receivedExp.Error);
+                Assert.AreEqual(payload, received);
+            }
+            finally
+            {
+                if (File.Exists(tempFile)) File.Delete(tempFile);
+            }
+        }
+    }
+}

--- a/Tests/PlayMode/StreamLifecycleTests.cs.meta
+++ b/Tests/PlayMode/StreamLifecycleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2bc9f6fd8de346849ec9cb189bdd16b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds 5 tests covering public data-stream APIs that had no dedicated coverage:

EditMode (4 tests, Tests/EditMode/RoomStreamHandlerTests.cs):
- Duplicate topic registration (text + byte) throws StreamError with a message that identifies the topic
- Unregister then re-register the same topic is allowed

PlayMode (1 test, Tests/PlayMode/StreamLifecycleTests.cs):
- SendFile_RecipientReceivesBytes: writes a temp file, sends via LocalParticipant.SendFile(path, topic), asserts the subscriber's ByteStreamHandler gets a reader whose ReadAll returns the same bytes.

Validated: EditMode 4/4 pass; PlayMode -n 5 * 1 test = 5/5 stable.