### PR TITLE
Batch 5: EditMode E2EE data-holder coverage (functional pivot)

### DIFF
--- a/Tests/EditMode/E2EEDataTests.cs
+++ b/Tests/EditMode/E2EEDataTests.cs
@@ -1,0 +1,80 @@
+using NUnit.Framework;
+
+namespace LiveKit.EditModeTests
+{
+    /// <summary>
+    /// EditMode coverage for the public E2EE data-holder surface. Functional coverage
+    /// (KeyProvider round-trips, E2EE-enabled room media flow) is deferred: the
+    /// KeyProvider FFI methods currently use the wrong request type (SetSharedKeyRequest
+    /// directly rather than a wrapping E2eeRequest), so every call throws
+    /// "Unknown request type" at dispatch. See Logs~/More Claude Tests 3/e2ee-findings.html
+    /// for details.
+    /// </summary>
+    public class E2EEDataTests
+    {
+        [Test]
+        public void EncryptionType_Values_MatchDocumentedConstants()
+        {
+            Assert.AreEqual(0, (int)EncryptionType.NONE);
+            Assert.AreEqual(1, (int)EncryptionType.GCM);
+            Assert.AreEqual(2, (int)EncryptionType.CUSTOM);
+        }
+
+        [Test]
+        public void KeyProviderOptions_DefaultInstance_HasNullKeysAndZeroCounters()
+        {
+            var options = new KeyProviderOptions();
+            Assert.IsNull(options.SharedKey);
+            Assert.IsNull(options.RatchetSalt);
+            Assert.AreEqual(0, options.RatchetWindowSize);
+            Assert.AreEqual(0, options.FailureTolerance);
+        }
+
+        [Test]
+        public void KeyProviderOptions_AllowsPublicFieldAssignment()
+        {
+            var key = new byte[] { 0x01, 0x02 };
+            var salt = new byte[] { 0xAA, 0xBB };
+            var options = new KeyProviderOptions
+            {
+                SharedKey = key,
+                RatchetSalt = salt,
+                RatchetWindowSize = 16,
+                FailureTolerance = 3
+            };
+
+            Assert.AreSame(key, options.SharedKey);
+            Assert.AreSame(salt, options.RatchetSalt);
+            Assert.AreEqual(16, options.RatchetWindowSize);
+            Assert.AreEqual(3, options.FailureTolerance);
+        }
+
+        [Test]
+        public void E2EEOptions_DefaultInstance_HasNullKeyProviderAndNoneEncryption()
+        {
+            var options = new E2EEOptions();
+            Assert.IsNull(options.KeyProviderOptions);
+            Assert.AreEqual(EncryptionType.NONE, options.EncryptionType);
+        }
+
+        [Test]
+        public void E2EEOptions_ToProto_DoesNotThrow()
+        {
+            var options = new E2EEOptions
+            {
+                EncryptionType = EncryptionType.GCM,
+                KeyProviderOptions = new KeyProviderOptions
+                {
+                    SharedKey = new byte[] { 0x01 },
+                    RatchetWindowSize = 16
+                }
+            };
+
+            // E2EEOptions.ToProto currently returns an empty proto (fields are not copied).
+            // This is tracked as a functional bug; this test just pins that ToProto is
+            // at least invokable so future fixes don't introduce a regression in throw
+            // behavior.
+            Assert.DoesNotThrow(() => options.ToProto());
+        }
+    }
+}

--- a/Tests/EditMode/E2EEDataTests.cs.meta
+++ b/Tests/EditMode/E2EEDataTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37a8f354f9bec4903947a8d211a071c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds 5 EditMode tests in Tests/EditMode/E2EEDataTests.cs covering the parts of the E2EE public surface that work today:

- EncryptionType enum values (NONE=0, GCM=1, CUSTOM=2)
- KeyProviderOptions default state (null keys, zero counters)
- KeyProviderOptions public field assignment round-trip
- E2EEOptions default state (null KeyProviderOptions, EncryptionType.NONE)
- E2EEOptions.ToProto() does not throw (pinning test — currently returns an empty proto, tracked as a bug)

Validation: -n 10 * 5 tests = 50/50 pass, zero flakes.

Originally-planned Batch 5 scope (KeyProvider round-trips, RatchetSharedKey, per-participant keys, E2EE-enabled room connection) was deferred after research revealed three structural bugs in the E2EE layer that prevent any functional test from completing:

1. Every KeyProvider FFI method uses the wrong request type (raw SetSharedKeyRequest etc. rather than a wrapping E2eeRequest), so every call throws "Unknown request type" at FfiRequestExtensions.Inject.
2. E2EEOptions.ToProto() returns an empty Proto.E2eeOptions — input fields are never copied, so E2EE cannot actually be enabled on a Room.
3. KeyProvider.SetKey drops its `key` parameter (never assigns it to the request).

These are intertwined (fixing #1 requires refactoring all six KeyProvider methods; fixing #2 is independent; #3 is trivially co-located with #1). Full writeup at Logs~/More Claude Tests 3/e2ee-findings.html. Recommending a single E2EE refactor PR before the originally-planned Batch 5 tests become writable.

Report on E2EE not working:
[Uploading e2ee-findings.html…]()
