### PR TITLE
Fix for incremental reader chunk-drop

### DIFF
--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -77,6 +77,7 @@ namespace LiveKit
     public abstract class ReadIncrementalInstructionBase<TContent> : StreamYieldInstruction
     {
         private readonly ulong _handleValue;
+        private readonly Queue<TContent> _pendingChunks = new();
         private TContent _latestChunk;
 
         /// <summary>
@@ -107,8 +108,26 @@ namespace LiveKit
 
         protected void OnChunk(TContent content)
         {
-            _latestChunk = content;
-            IsCurrentReadDone = true;
+            if (IsCurrentReadDone)
+            {
+                // Consumer hasn't yielded since the last chunk; buffer until Reset().
+                _pendingChunks.Enqueue(content);
+            }
+            else
+            {
+                _latestChunk = content;
+                IsCurrentReadDone = true;
+            }
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            if (_pendingChunks.Count > 0)
+            {
+                _latestChunk = _pendingChunks.Dequeue();
+                IsCurrentReadDone = true;
+            }
         }
 
         protected void OnEos(Proto.StreamError protoError)

--- a/Tests/EditMode/DataStreamIncrementalReadTests.cs
+++ b/Tests/EditMode/DataStreamIncrementalReadTests.cs
@@ -1,12 +1,11 @@
 using System;
 using System.Collections.Generic;
-using LiveKit;
 using LiveKit.Internal;
 using NUnit.Framework;
 
 namespace LiveKit.EditModeTests
 {
-    public class DataStreamIncrementalReadTests
+    public class DataStreamTests
     {
         private sealed class TestIncrementalReader : ReadIncrementalInstructionBase<string>
         {

--- a/Tests/EditMode/DataStreamIncrementalReadTests.cs
+++ b/Tests/EditMode/DataStreamIncrementalReadTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using LiveKit;
+using LiveKit.Internal;
+using NUnit.Framework;
+
+namespace LiveKit.EditModeTests
+{
+    public class DataStreamIncrementalReadTests
+    {
+        private sealed class TestIncrementalReader : ReadIncrementalInstructionBase<string>
+        {
+            public TestIncrementalReader(FfiHandle h) : base(h) { }
+            public void PushChunk(string content) => OnChunk(content);
+            public string Value => LatestChunk;
+        }
+
+        [Test]
+        public void OnChunk_MultipleChunksBeforeConsumerDrains_AllChunksAreObserved()
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+
+            // Three ChunkReceived events arrive back-to-back on the sync context,
+            // before the consumer coroutine resumes from its yield.
+            reader.PushChunk("A");
+            reader.PushChunk("B");
+            reader.PushChunk("C");
+
+            // Drain like a consumer would: read the current chunk, Reset, loop
+            // while more is readable.
+            var observed = new List<string>();
+            while (!reader.keepWaiting)
+            {
+                observed.Add(reader.Value);
+                if (reader.IsEos) break;
+                reader.Reset();
+            }
+
+            CollectionAssert.AreEqual(new[] { "A", "B", "C" }, observed,
+                "ReadIncrementalInstructionBase dropped chunks when multiple " +
+                "ChunkReceived events arrived before the consumer could yield.");
+        }
+    }
+}

--- a/Tests/EditMode/DataStreamIncrementalReadTests.cs.meta
+++ b/Tests/EditMode/DataStreamIncrementalReadTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7a470a34daf846b982b6ba9462d450f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add a single EditMode regression test that pins down the chunk-drop bug in `ReadIncrementalInstructionBase<T>`.
- The base class stores each `OnChunk` call into a single `_latestChunk` field, so when several `ChunkReceived` FFI events are dispatched on the same sync-context flush (common: multiple chunks arriving between Unity frames), earlier chunks are silently overwritten before the consumer coroutine can resume from its yield.
- No Runtime changes in this PR — the queue-backed fix lands on a follow-up branch once this failing test is in place.

## Test plan
- [x] Add just the new unit test without the fix and see the CI tests fail:
https://github.com/livekit/client-sdk-unity/actions/runs/24781354985?pr=259

- [x] Fix bug in 2nd commit will make this test go green without changing the test itself.