### PR TITLE
Activate GC handle cleanup test again

### DIFF
--- a/Tests/PlayMode/FfiHandleDisposalTests.cs
+++ b/Tests/PlayMode/FfiHandleDisposalTests.cs
@@ -15,7 +15,7 @@ namespace LiveKit.PlayModeTests
         /// The Rust drop implementation for outgoing data streams requires a Tokio
         /// runtime, which doesn't exist on the GC finalizer thread right now. That
         /// is why it is a [Known Issue]
-        [UnityTest, Category("E2E"), Ignore("Known issue: CLT-2773")]
+        [UnityTest, Category("E2E")]
         public IEnumerator StreamWriter_LeakedHandle_DoesNotCrashOnGC()
         {
             LogAssert.ignoreFailingMessages = true;


### PR DESCRIPTION
### Background

The GC cleans up the handle and this crashed in Rust, so we had one test disabled. 
The bumped FFI includes the fix: https://github.com/livekit/rust-sdks/pull/1016
We can enable the test.

Test run failing before Rust FFI bump: https://github.com/livekit/client-sdk-unity/actions/runs/25053369625?pr=264

### Changes

- enable `StreamWriter_LeakedHandle_DoesNotCrashOnGC` test