### PR TITLE
Meet: Moved video texture inversion from client code into the SDK

### DIFF
--- a/Resources/Shaders/YuvToRgb.shader
+++ b/Resources/Shaders/YuvToRgb.shader
@@ -54,8 +54,8 @@ Shader "Hidden/LiveKit/YUV2RGB"
 
             half4 frag(v2f i) : SV_Target
             {
-                // Flip horizontally to match Unity's texture orientation with incoming YUV data
-                half2 uv = half2(1.0h - i.uv.x, i.uv.y);
+                // Flip vertically to match Unity's texture orientation with incoming YUV data
+                half2 uv = half2(i.uv.x, 1.0h - i.uv.y);
 
                 half y = tex2D(_TexY, uv).r;
                 half u = tex2D(_TexU, uv).r;

--- a/Runtime/Scripts/Video/YuvToRgbConverter.cs
+++ b/Runtime/Scripts/Video/YuvToRgbConverter.cs
@@ -14,6 +14,8 @@ namespace LiveKit
 		private Texture2D _planeU;
 		private Texture2D _planeV;
 
+		private const string SHADER_NAME = "Hidden/LiveKit/YUV2RGB";
+
 		// Ensure Output exists and matches the given size; returns true if created or resized.
 		public bool EnsureOutput(int width, int height)
 		{
@@ -79,7 +81,7 @@ namespace LiveKit
 		{
 			if (_yuvToRgbMaterial == null)
 			{
-				var shader = Shader.Find("Hidden/LiveKit/YUV2RGB");
+				var shader = Shader.Find(SHADER_NAME);
 				if (shader != null)
 					_yuvToRgbMaterial = new Material(shader);
 			}
@@ -134,8 +136,8 @@ namespace LiveKit
 				tempTex.LoadRawTextureData((IntPtr)rgba.Info.DataPtr, (int)rgba.GetMemorySize());
 				tempTex.Apply();
 				
-				// Also mirror horizontally by flipping the UV scale on the X axis and offsetting.
-				Graphics.Blit(tempTex, Output, new Vector2(-1f, 1f), new Vector2(1f, 0f));
+				// Mirror vertically to match the GPU shader path's UV remap.
+				Graphics.Blit(tempTex, Output, new Vector2(1f, -1f), new Vector2(0f, 1f));
 			}
 			finally
 			{

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -210,7 +210,7 @@ public class MeetManager : MonoBehaviour
     private void AddRemoteVideoTrack(RemoteVideoTrack videoTrack)
     {
         var sid = videoTrack.Sid;
-        var imageObject = CreateVideoDisplay(sid, invert: true);
+        var imageObject = CreateVideoDisplay(sid);
 
         var image = imageObject.GetComponent<RawImage>();
         var stream = new VideoStream(videoTrack);
@@ -437,11 +437,9 @@ public class MeetManager : MonoBehaviour
         button.GetComponentInChildren<MaterialIcon>().iconUnicode = unicode;
     }
 
-    private GameObject CreateVideoDisplay(string name, bool invert = false)
+    private GameObject CreateVideoDisplay(string name)
     {
         var obj = new GameObject(name);
-        var rect = obj.AddComponent<RectTransform>();
-        if (invert) rect.rotation = Quaternion.Euler(0, 0, 180);
         obj.AddComponent<RawImage>();
         return obj;
     }


### PR DESCRIPTION
### Background

I added a quick fix to handle the videos in our Meet sample, which where somehow rotated 180 degrees. Revisiting this I wanted to make the proper fix, moving the rotation from the client code into the SDK. There was something wrong with our Shader code.

### Changes

- Adding the correct texture orientation into the YUV conversion step
- Removing texture inversion in Meet sample