### PR TITLE
Dispatch log batches off the main thread

### DIFF
--- a/Runtime/Scripts/Internal/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFIClient.cs
@@ -287,6 +287,15 @@ namespace LiveKit.Internal
                 return;
             }
 
+            // Log batches are forwarded directly: UnityEngine.Debug.unityLogger is thread-safe,
+            // and in verbose builds logs can flood at a rate where round-tripping through the
+            // main-thread post queue would be wasteful with no user-visible benefit.
+            if (response.MessageCase == FfiEvent.MessageOneofCase.Logs)
+            {
+                Utils.HandleLogBatch(response.Logs);
+                return;
+            }
+
             // Run on the main thread, the order of execution is guaranteed by Unity
             // It uses a Queue internally
             Instance._context?.Post(static (resp) =>
@@ -316,9 +325,6 @@ namespace LiveKit.Internal
 
             switch (ffiEvent.MessageCase)
             {
-                case FfiEvent.MessageOneofCase.Logs:
-                    Utils.HandleLogBatch(ffiEvent.Logs);
-                    break;
                 case FfiEvent.MessageOneofCase.PublishData:
                     break;
                 case FfiEvent.MessageOneofCase.RoomEvent:


### PR DESCRIPTION
Logs from Rust were going through SynchronizationContext.Post like every other event, which is wasteful: UnityEngine.Debug.unityLogger is thread-safe, log batches are SDK-internal (no user callback expectation), and in LK_VERBOSE builds they can flood the post queue.

Forward them inline from the FFI callback alongside AudioStreamEvent and remove the now-unreachable Logs case from DispatchEvent.