### PR TITLE
Cleanup Audio Dispatch

### DIFF
--- a/Runtime/Scripts/Internal/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFIClient.cs
@@ -338,9 +338,6 @@ namespace LiveKit.Internal
                 case FfiEvent.MessageOneofCase.VideoStreamEvent:
                     Instance.VideoStreamEventReceived?.Invoke(ffiEvent.VideoStreamEvent!);
                     break;
-                case FfiEvent.MessageOneofCase.AudioStreamEvent:
-                    Instance.AudioStreamEventReceived?.Invoke(ffiEvent.AudioStreamEvent!);
-                    break;
                 case FfiEvent.MessageOneofCase.ByteStreamReaderEvent:
                     Instance.ByteStreamReaderEventReceived?.Invoke(ffiEvent.ByteStreamReaderEvent!);
                     break;


### PR DESCRIPTION
### Background

Audio dispatch is handled separately and happens above the main thread dispatch and switch case:
```
if (response.MessageCase == FfiEvent.MessageOneofCase.AudioStreamEvent)
{
  Instance.AudioStreamEventReceived?.Invoke(response.AudioStreamEvent!);
  return;
}
```

### Changes

- Remove case FfiEvent.MessageOneofCase.AudioStreamEvent from switch case