### PR TITLE
Scope precompiled DLLs to LiveKit asmdef to avoid clashes

### DIFF
--- a/Runtime/Plugins/Google.Protobuf.dll.meta
+++ b/Runtime/Plugins/Google.Protobuf.dll.meta
@@ -8,7 +8,7 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 0
   isOverridable: 1
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:

--- a/Runtime/Plugins/System.Runtime.CompilerServices.Unsafe.dll.meta
+++ b/Runtime/Plugins/System.Runtime.CompilerServices.Unsafe.dll.meta
@@ -8,7 +8,7 @@ PluginImporter:
   defineConstraints: []
   isPreloaded: 1
   isOverridable: 1
-  isExplicitlyReferenced: 0
+  isExplicitlyReferenced: 1
   validateReferences: 1
   platformData:
   - first:

--- a/Runtime/livekit.unity.Runtime.asmdef
+++ b/Runtime/livekit.unity.Runtime.asmdef
@@ -5,8 +5,12 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Google.Protobuf.dll",
+        "System.Runtime.CompilerServices.Unsafe.dll",
+        "Newtonsoft.Json.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],


### PR DESCRIPTION
## Summary
- Mark `Google.Protobuf.dll` and `System.Runtime.CompilerServices.Unsafe.dll` as `isExplicitlyReferenced: 1`
- Switch `livekit.unity.Runtime.asmdef` to `overrideReferences: true` and explicitly list our precompiled deps (`Google.Protobuf.dll`, `System.Runtime.CompilerServices.Unsafe.dll`, `Newtonsoft.Json.dll`)
- Result: our bundled DLL versions are scoped to the LiveKit assembly only, so other packages bundling their own copies (e.g. `com.unity.ai.assistant`) no longer trigger Unity's "Duplicate assembly with different versions detected" CS0246/CS0538 cascade

## Background
With `com.unity.ai.assistant` (which ships `Google.Protobuf 3.33.2` and `System.Runtime.CompilerServices.Unsafe 6.0.3`) installed in a project, Unity's duplicate-assembly detection picked the AI Assistant's newer DLLs over ours, but their copies are `isExplicitlyReferenced: 1` and editor-only — so they didn't auto-reference into the LiveKit assembly either. Result: LiveKit ended up with no Google.Protobuf reference at all, breaking `Runtime/Scripts/Proto/*.cs`.

Marking our DLLs as explicitly-referenced and binding them to the LiveKit asmdef via `overrideReferences` + `precompiledReferences` keeps our copies scoped to LiveKit's compilation unit and out of the project-wide auto-reference pool, so the duplicate detection no longer affects us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)