### PR TITLE
Remove Unity resampling

### DIFF
--- a/Runtime/Scripts/AudioStream.cs
+++ b/Runtime/Scripts/AudioStream.cs
@@ -13,7 +13,14 @@ namespace LiveKit
     /// </summary>
     public sealed class AudioStream : IDisposable
     {
-        internal readonly FfiHandle Handle;
+        // FFI native stream is created lazily on the first OnAudioRead so we can pass
+        // Unity's actual delivered (channels, sampleRate) — not a system-speaker-mode
+        // guess. _handle is null until CreateFfiStream completes on the main thread.
+        private FfiHandle _handle;
+        internal FfiHandle Handle => _handle;
+        private readonly ulong _trackHandleId;
+        private bool _ffiCreatePosted;
+
         private readonly AudioSource _audioSource;
         private AudioProbe _probe;
         private RingBuffer _buffer;
@@ -21,7 +28,6 @@ namespace LiveKit
         private short[] _crossfadeScratch;
         private uint _numChannels;
         private uint _sampleRate;
-        private AudioResampler _resampler = new AudioResampler();
         private readonly object _lock = new object();
         private bool _disposed = false;
 
@@ -56,15 +62,7 @@ namespace LiveKit
             if (!audioTrack.Participant.TryGetTarget(out var participant))
                 throw new InvalidOperationException("audiotrack's participant is invalid");
 
-            using var request = FFIBridge.Instance.NewRequest<NewAudioStreamRequest>();
-            var newAudioStream = request.request;
-            newAudioStream.TrackHandle = (ulong)(audioTrack as ITrack).TrackHandle.DangerousGetHandle();
-            newAudioStream.Type = AudioStreamType.AudioStreamNative;
-
-            using var response = request.Send();
-            FfiResponse res = response;
-            Handle = FfiHandle.FromOwnedHandle(res.NewAudioStream.Stream.Handle);
-            FfiClient.Instance.AudioStreamEventReceived += OnAudioStreamEvent;
+            _trackHandleId = (ulong)(audioTrack as ITrack).TrackHandle.DangerousGetHandle();
 
             _audioSource = source;
             _probe = _audioSource.gameObject.AddComponent<AudioProbe>();
@@ -78,6 +76,45 @@ namespace LiveKit
             // (e.g. headphones unplugged). Without re-playing the source, OnAudioFilterRead
             // stops firing and the stream goes silent until the AudioStream is recreated.
             AudioSettings.OnAudioConfigurationChanged += OnAudioConfigurationChanged;
+
+            // FFI stream creation is deferred to the first OnAudioRead. We subscribe to
+            // AudioStreamEventReceived only after the stream exists (CreateFfiStream).
+        }
+
+        // Called on the main thread (posted from OnAudioRead via FfiClient._context) once
+        // we know Unity's actual playback (channels, sampleRate). Builds the native stream
+        // request so Rust delivers frames already at the right format — no resample on this
+        // side, no FFI reconfigure dance later.
+        private void CreateFfiStream(uint observedChannels, uint observedSampleRate)
+        {
+            lock (_lock) { if (_disposed) return; }
+
+            FfiHandle newHandle;
+            try
+            {
+                using var request = FFIBridge.Instance.NewRequest<NewAudioStreamRequest>();
+                var req = request.request;
+                req.TrackHandle = _trackHandleId;
+                req.Type = AudioStreamType.AudioStreamNative;
+                req.SampleRate = observedSampleRate;
+                req.NumChannels = observedChannels;
+
+                using var response = request.Send();
+                FfiResponse res = response;
+                newHandle = FfiHandle.FromOwnedHandle(res.NewAudioStream.Stream.Handle);
+            }
+            catch (Exception ex)
+            {
+                Utils.Error($"AudioStream FFI create failed: {ex}");
+                return;
+            }
+
+            lock (_lock)
+            {
+                if (_disposed) { newHandle.Dispose(); return; }
+                _handle = newHandle;
+                FfiClient.Instance.AudioStreamEventReceived += OnAudioStreamEvent;
+            }
         }
 
         // Called on Unity audio thread
@@ -91,6 +128,22 @@ namespace LiveKit
 
             lock (_lock)
             {
+                // First OnAudioRead: post a one-shot CreateFfiStream to the main thread
+                // with Unity's actual (channels, sampleRate). Until the FFI stream exists
+                // we output silence — the priming window absorbs this gap.
+                if (_handle == null)
+                {
+                    if (!_ffiCreatePosted)
+                    {
+                        _ffiCreatePosted = true;
+                        uint observedCh = (uint)channels;
+                        uint observedSr = (uint)sampleRate;
+                        FfiClient.Instance._context?.Post(_ => CreateFfiStream(observedCh, observedSr), null);
+                    }
+                    Array.Clear(data, 0, data.Length);
+                    return;
+                }
+
                 // Initialize or reinitialize buffer if audio format changed
                 if (_buffer == null || channels != _numChannels || sampleRate != _sampleRate || data.Length != _tempBuffer.Length)
                 {
@@ -284,18 +337,13 @@ namespace LiveKit
 
             lock (_lock)
             {
-                if (_numChannels == 0)
+                if (_buffer == null)
                     return;
 
                 unsafe
                 {
-                    using var uFrame = _resampler.RemixAndResample(frame, _numChannels, _sampleRate);
-                    if (uFrame != null)
-                    {
-                        var data = new Span<byte>(uFrame.Data.ToPointer(), uFrame.Length);
-                        _buffer?.Write(data);
-                    }
-
+                    var data = new ReadOnlySpan<byte>(frame.Data.ToPointer(), frame.Length);
+                    _buffer.Write(data);
                 }
             }
         }
@@ -315,8 +363,11 @@ namespace LiveKit
 
             // Remove long-lived delegate references first so this instance can become collectible
             // as soon as user code drops it. This also prevents late native callbacks from
-            // touching partially disposed state.
-            FfiClient.Instance.AudioStreamEventReceived -= OnAudioStreamEvent;
+            // touching partially disposed state. AudioStreamEventReceived was only subscribed
+            // after CreateFfiStream succeeded; -= against an unsubscribed handler is a no-op,
+            // but the explicit guard documents the lifecycle.
+            if (_handle != null)
+                FfiClient.Instance.AudioStreamEventReceived -= OnAudioStreamEvent;
             MonoBehaviourContext.OnApplicationPauseEvent -= OnApplicationPause;
             AudioSettings.OnAudioConfigurationChanged -= OnAudioConfigurationChanged;
 
@@ -339,9 +390,8 @@ namespace LiveKit
                 _buffer = null;
                 _tempBuffer = null;
                 _crossfadeScratch = null;
-                _resampler?.Dispose();
-                _resampler = null;
-                Handle.Dispose();
+                _handle?.Dispose();
+                _handle = null;
             }
 
             _disposed = true;

--- a/Runtime/Scripts/AudioStream.cs
+++ b/Runtime/Scripts/AudioStream.cs
@@ -15,11 +15,15 @@ namespace LiveKit
     {
         // FFI native stream is created lazily on the first OnAudioRead so we can pass
         // Unity's actual delivered (channels, sampleRate) — not a system-speaker-mode
-        // guess. _handle is null until CreateFfiStream completes on the main thread.
+        // guess. _handle is null until CreateOrRecreateFfiStream completes on the main
+        // thread. The same path runs again whenever Unity's delivered format changes
+        // mid-stream (e.g. after a system audio device switch).
         private FfiHandle _handle;
         internal FfiHandle Handle => _handle;
         private readonly ulong _trackHandleId;
-        private bool _ffiCreatePosted;
+        private uint _ffiNumChannels;
+        private uint _ffiSampleRate;
+        private bool _pendingFfiRequest;
 
         private readonly AudioSource _audioSource;
         private AudioProbe _probe;
@@ -81,11 +85,12 @@ namespace LiveKit
             // AudioStreamEventReceived only after the stream exists (CreateFfiStream).
         }
 
-        // Called on the main thread (posted from OnAudioRead via FfiClient._context) once
-        // we know Unity's actual playback (channels, sampleRate). Builds the native stream
-        // request so Rust delivers frames already at the right format — no resample on this
-        // side, no FFI reconfigure dance later.
-        private void CreateFfiStream(uint observedChannels, uint observedSampleRate)
+        // Called on the main thread (posted from OnAudioRead via FfiClient._context) when
+        // either there is no FFI stream yet or Unity's delivered (channels, sampleRate) no
+        // longer matches what we asked Rust for. Builds a fresh native stream and swaps it
+        // in atomically. The old handle is disposed AFTER the swap so any in-flight frames
+        // from the old stream fail the handle-id filter in OnAudioStreamEvent.
+        private void CreateOrRecreateFfiStream(uint observedChannels, uint observedSampleRate)
         {
             lock (_lock) { if (_disposed) return; }
 
@@ -105,16 +110,30 @@ namespace LiveKit
             }
             catch (Exception ex)
             {
-                Utils.Error($"AudioStream FFI create failed: {ex}");
+                Utils.Error($"AudioStream FFI (re)create failed: {ex}");
+                lock (_lock) { _pendingFfiRequest = false; }
                 return;
             }
 
+            FfiHandle oldHandle;
+            bool firstCreate;
             lock (_lock)
             {
                 if (_disposed) { newHandle.Dispose(); return; }
+                oldHandle = _handle;
+                firstCreate = oldHandle == null;
                 _handle = newHandle;
-                FfiClient.Instance.AudioStreamEventReceived += OnAudioStreamEvent;
+                _ffiNumChannels = observedChannels;
+                _ffiSampleRate = observedSampleRate;
+                _buffer?.Clear();
+                _isPrimed = false;
+                _skipCooldown = 0;
+                _pendingFfiRequest = false;
+
+                if (firstCreate)
+                    FfiClient.Instance.AudioStreamEventReceived += OnAudioStreamEvent;
             }
+            oldHandle?.Dispose();
         }
 
         // Called on Unity audio thread
@@ -128,17 +147,18 @@ namespace LiveKit
 
             lock (_lock)
             {
-                // First OnAudioRead: post a one-shot CreateFfiStream to the main thread
-                // with Unity's actual (channels, sampleRate). Until the FFI stream exists
-                // we output silence — the priming window absorbs this gap.
-                if (_handle == null)
+                // Single gate covering first-create and runtime format changes (e.g. after a
+                // system audio device switch). When the FFI stream is missing or what we asked
+                // Rust for no longer matches what Unity is delivering, post a (re)create to the
+                // main thread and output silence until it lands. The priming window absorbs this.
+                if (_handle == null || channels != _ffiNumChannels || sampleRate != _ffiSampleRate)
                 {
-                    if (!_ffiCreatePosted)
+                    if (!_pendingFfiRequest)
                     {
-                        _ffiCreatePosted = true;
+                        _pendingFfiRequest = true;
                         uint observedCh = (uint)channels;
                         uint observedSr = (uint)sampleRate;
-                        FfiClient.Instance._context?.Post(_ => CreateFfiStream(observedCh, observedSr), null);
+                        FfiClient.Instance._context?.Post(_ => CreateOrRecreateFfiStream(observedCh, observedSr), null);
                     }
                     Array.Clear(data, 0, data.Length);
                     return;
@@ -337,7 +357,12 @@ namespace LiveKit
 
             lock (_lock)
             {
-                if (_buffer == null)
+                // _pendingFfiRequest gates writes during a (re)create: between the moment
+                // OnAudioRead detects a format mismatch and the swap landing, Rust is still
+                // emitting frames at the OLD format. Drop them to avoid corrupting the buffer.
+                // The handle-id filter above is the second line of defense for stragglers
+                // arriving from the old stream after the swap.
+                if (_buffer == null || _pendingFfiRequest)
                     return;
 
                 unsafe

--- a/Tests/EditMode/MediaStreamLifetimeTests.cs
+++ b/Tests/EditMode/MediaStreamLifetimeTests.cs
@@ -124,8 +124,7 @@ namespace LiveKit.EditModeTests
             StringAssert.Contains("_probe.AudioRead -= OnAudioRead;", source);
             StringAssert.Contains("AudioSettings.OnAudioConfigurationChanged -= OnAudioConfigurationChanged;", source);
             StringAssert.Contains("_buffer?.Dispose();", source);
-            StringAssert.Contains("_resampler?.Dispose();", source);
-            StringAssert.Contains("Handle.Dispose();", source);
+            StringAssert.Contains("_handle?.Dispose();", source);
         }
 
         [Test]
@@ -133,10 +132,10 @@ namespace LiveKit.EditModeTests
         {
             var source = ReadSource(AudioStreamPaths);
 
-            // Both the inbound native frame and the remixed output frame should be scoped so their
-            // handles are released after each callback rather than accumulating over time.
+            // Native frames carry an FFI handle that must be released after each callback so they
+            // do not accumulate. With the Rust side delivering frames already at Unity's rate, we
+            // no longer wrap a resampled output frame.
             StringAssert.Contains("using var frame = new AudioFrame(e.FrameReceived.Frame);", source);
-            StringAssert.Contains("using var uFrame = _resampler.RemixAndResample(frame, _numChannels, _sampleRate);", source);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Remove second resampling in Unity, by configuring the Rust audio stream with correct `(channels, sampleRate)` to begin with. The problem is, that in Unity you don't know the channel number of each audio source until it runs, so we need to delay the initialization of the native audio stream until audio is read in Unity. The same lazy-create path is reused to **recreate the native audio stream when Unity's delivered format changes mid-stream** — for example after a system audio device switch.

## Changes

- **Drop C# `RemixAndResample` per-frame path.** `OnAudioStreamEvent` now just memcpys the inbound `AudioFrame` into the ring buffer — no FFI roundtrip on the OS-audio-scheduled callback thread. Rust's `NativeAudioStream` does the rate/channel conversion internally, once, with its existing pipeline.
- **Lazily create the FFI native stream from the first `OnAudioRead`.** `AudioSettings.GetConfiguration().speakerMode` disagrees with what `OnAudioFilterRead` actually delivers when the AudioSource is routed differently (per-source mono routing, spatializers, mixer chains, headphone profiles) — observed on macOS Editor + Sony headphones (system Stereo, source mono → low-pitched playback). The first callback is the authoritative source for `(channels, sampleRate)`; we post a one-shot `CreateOrRecreateFfiStream(...)` to the main thread via `FfiClient._context`, build the `NewAudioStreamRequest` with the observed values, and only then subscribe to `AudioStreamEventReceived`.
- **Recreate the native stream when Unity's delivered format changes.** A single gate in `OnAudioRead` covers both first-create and runtime mismatch (`channels != _ffiNumChannels || sampleRate != _ffiSampleRate`). On mismatch we post the same `CreateOrRecreateFfiStream` to the main thread; the new stream is built outside the lock, then under the lock we swap `_handle`, update the `_ffi*` trackers, clear the buffer, reset priming, and clear the `_pendingFfiRequest` flag. Old handle is disposed AFTER the swap so its Rust task exits cleanly. `OnAudioStreamEvent` drops frames while `_pendingFfiRequest` is set so old-format bytes don't land in the new buffer; the existing handle-id filter catches any in-flight stragglers from the old stream after the swap. This pairs with #274 (re-attach `AudioProbe` and re-`Play()` the AudioSource on device change) so audio resumes seamlessly when the user plugs/unplugs headphones, switches Bluetooth devices, etc.

## Files

- `Runtime/Scripts/AudioStream.cs` — `_resampler` field gone; `Handle` is now `_handle` behind a property; `CreateOrRecreateFfiStream` added; `_ffiNumChannels`/`_ffiSampleRate`/`_pendingFfiRequest` track FFI-side configuration; constructor only sets up AudioSource/AudioProbe/pause hook.
- `Tests/EditMode/MediaStreamLifetimeTests.cs` — assertions updated for the renamed/removed members.

## Profiler

Before change, after 5 minutes and multiple audio sources: **Total Audio CPU** reaches ~100%
<img width="199" height="240" alt="Screenshot 2026-05-06 at 14 47 09" src="https://github.com/user-attachments/assets/c6c3e5a6-41ff-4d47-9126-8ba97c198c83" />

________________________________________________________________________________

With change, after 5 minutes and multiple audio sources: **Total Audio CPU** stays below ~10%
<img width="199" height="240" alt="Screenshot 2026-05-06 at 14 46 48" src="https://github.com/user-attachments/assets/35cf514b-5de6-4022-8bfa-337d70235aef" />