### PR TITLE
TokenSourceComponent: switch from async/await to coroutine

### DIFF
--- a/Runtime/Scripts/Internal/TaskYieldInstruction.cs
+++ b/Runtime/Scripts/Internal/TaskYieldInstruction.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+
+namespace LiveKit
+{
+    /// <summary>
+    /// Adapts a <see cref="Task{TResult}"/> to a coroutine-friendly <see cref="YieldInstruction"/>.
+    /// Yield on it from a coroutine, then read <see cref="Result"/> on success or
+    /// <see cref="Exception"/> when <see cref="YieldInstruction.IsError"/> is true.
+    /// </summary>
+    public sealed class TaskYieldInstruction<T> : YieldInstruction
+    {
+        public T Result { get; private set; }
+        public Exception Exception { get; private set; }
+
+        internal TaskYieldInstruction(Task<T> task)
+        {
+            // Continuation may run on a thread-pool thread; the volatile IsDone/IsError fields in
+            // the base class give the polling main thread acquire semantics for Result/Exception.
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    Exception = t.Exception?.InnerException ?? t.Exception;
+                    IsError = true;
+                }
+                else if (t.IsCanceled)
+                {
+                    IsError = true;
+                }
+                else
+                {
+                    Result = t.Result;
+                }
+                IsDone = true;
+            });
+        }
+    }
+}

--- a/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
@@ -20,7 +20,7 @@ namespace LiveKit
         /// Fetches connection details using only the values on the asset-backed
         /// <see cref="TokenSourceComponentConfig"/>. Equivalent to <c>FetchConnectionDetails(null)</c>.
         /// </summary>
-        public FetchConnectionDetailsInstruction FetchConnectionDetails() => FetchConnectionDetails(null);
+        public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails() => FetchConnectionDetails(null);
 
         ITokenSource _tokenSource;
 
@@ -56,7 +56,7 @@ namespace LiveKit
         /// overrides the config value (empty strings are treated as unset and fall through to the config).
         /// Ignored for fixed token sources (<see cref="TokenSourceLiteral"/>, <see cref="TokenSourceCustom"/>).
         /// </summary>
-        public FetchConnectionDetailsInstruction FetchConnectionDetails(TokenSourceFetchOptions options)
+        public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions options)
         {
             Task<ConnectionDetails> task;
             switch (_tokenSource)
@@ -74,7 +74,7 @@ namespace LiveKit
                 default:
                     throw new InvalidOperationException("Unknown token source type");
             }
-            return new FetchConnectionDetailsInstruction(task);
+            return new TaskYieldInstruction<ConnectionDetails>(task);
         }
 
         private static TokenSourceFetchOptions Coalesce(TokenSourceComponentConfig config, TokenSourceFetchOptions? options)
@@ -114,39 +114,5 @@ namespace LiveKit
 
         private static string Coalesce(string primary, string fallback) =>
             NullIfEmpty(primary) ?? NullIfEmpty(fallback);
-    }
-
-    /// <summary>
-    /// Coroutine yield instruction returned by <see cref="TokenSourceComponent.FetchConnectionDetails()"/>.
-    /// Yield on it from a coroutine, then read <see cref="Result"/> (on success) or <see cref="Exception"/>
-    /// (when <see cref="YieldInstruction.IsError"/> is true).
-    /// </summary>
-    public sealed class FetchConnectionDetailsInstruction : YieldInstruction
-    {
-        public ConnectionDetails Result { get; private set; }
-        public Exception Exception { get; private set; }
-
-        internal FetchConnectionDetailsInstruction(Task<ConnectionDetails> task)
-        {
-            // Continuation may run on a thread-pool thread; the volatile IsDone/IsError fields in
-            // the base class give the polling main thread acquire semantics for Result/Exception.
-            task.ContinueWith(t =>
-            {
-                if (t.IsFaulted)
-                {
-                    Exception = t.Exception?.InnerException ?? t.Exception;
-                    IsError = true;
-                }
-                else if (t.IsCanceled)
-                {
-                    IsError = true;
-                }
-                else
-                {
-                    Result = t.Result;
-                }
-                IsDone = true;
-            });
-        }
     }
 }

--- a/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
@@ -20,7 +20,7 @@ namespace LiveKit
         /// Fetches connection details using only the values on the asset-backed
         /// <see cref="TokenSourceComponentConfig"/>. Equivalent to <c>FetchConnectionDetails(null)</c>.
         /// </summary>
-        public Task<ConnectionDetails> FetchConnectionDetails() => FetchConnectionDetails(null);
+        public FetchConnectionDetailsInstruction FetchConnectionDetails() => FetchConnectionDetails(null);
 
         ITokenSource _tokenSource;
 
@@ -56,22 +56,26 @@ namespace LiveKit
         /// overrides the config value (empty strings are treated as unset and fall through to the config).
         /// Ignored for fixed token sources (<see cref="TokenSourceLiteral"/>, <see cref="TokenSourceCustom"/>).
         /// </summary>
-        public async Task<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions? options)   
+        public FetchConnectionDetailsInstruction FetchConnectionDetails(TokenSourceFetchOptions options)
         {
+            Task<ConnectionDetails> task;
             switch (_tokenSource)
             {
                 case ITokenSourceConfigurable configurableSource:
-                    return await configurableSource.FetchConnectionDetails(Coalesce(_config, options));
-        
+                    task = configurableSource.FetchConnectionDetails(Coalesce(_config, options));
+                    break;
+
                 case ITokenSourceFixed fixedSource:
                     if (options != null)
                         Debug.LogWarning("TokenSourceComponent uses a fixed config, so fetch options are ignored.");
-                    return await fixedSource.FetchConnectionDetails();
+                    task = fixedSource.FetchConnectionDetails();
+                    break;
 
                 default:
                     throw new InvalidOperationException("Unknown token source type");
-            }                                                                                          
-        }       
+            }
+            return new FetchConnectionDetailsInstruction(task);
+        }
 
         private static TokenSourceFetchOptions Coalesce(TokenSourceComponentConfig config, TokenSourceFetchOptions? options)
         {
@@ -110,5 +114,39 @@ namespace LiveKit
 
         private static string Coalesce(string primary, string fallback) =>
             NullIfEmpty(primary) ?? NullIfEmpty(fallback);
+    }
+
+    /// <summary>
+    /// Coroutine yield instruction returned by <see cref="TokenSourceComponent.FetchConnectionDetails()"/>.
+    /// Yield on it from a coroutine, then read <see cref="Result"/> (on success) or <see cref="Exception"/>
+    /// (when <see cref="YieldInstruction.IsError"/> is true).
+    /// </summary>
+    public sealed class FetchConnectionDetailsInstruction : YieldInstruction
+    {
+        public ConnectionDetails Result { get; private set; }
+        public Exception Exception { get; private set; }
+
+        internal FetchConnectionDetailsInstruction(Task<ConnectionDetails> task)
+        {
+            // Continuation may run on a thread-pool thread; the volatile IsDone/IsError fields in
+            // the base class give the polling main thread acquire semantics for Result/Exception.
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    Exception = t.Exception?.InnerException ?? t.Exception;
+                    IsError = true;
+                }
+                else if (t.IsCanceled)
+                {
+                    IsError = true;
+                }
+                else
+                {
+                    Result = t.Result;
+                }
+                IsDone = true;
+            });
+        }
     }
 }

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -157,16 +157,16 @@ public class MeetManager : MonoBehaviour
     {
         if (_room != null) yield break;
 
-        var connectionDetailsTask = _tokenSourceComponent.FetchConnectionDetails(new TokenSourceFetchOptions());
-        yield return new WaitUntil(() => connectionDetailsTask.IsCompleted);
+        var fetch = _tokenSourceComponent.FetchConnectionDetails(new TokenSourceFetchOptions());
+        yield return fetch;
 
-        if (connectionDetailsTask.IsFaulted)
+        if (fetch.IsError)
         {
-            Debug.LogError($"Failed to fetch connection details: {connectionDetailsTask.Exception?.InnerException?.Message}");
+            Debug.LogError($"Failed to fetch connection details: {fetch.Exception?.Message}");
             yield break;
         }
 
-        var details = connectionDetailsTask.Result;
+        var details = fetch.Result;
 
         _room = new Room();
         _room.TrackSubscribed += OnTrackSubscribed;


### PR DESCRIPTION
## Summary
- Convert `TokenSourceComponent.FetchConnectionDetails` from `async Task<ConnectionDetails>` to a coroutine-style API to match the rest of the SDK (`Room.Connect`, `PublishTrack`, etc., all return `YieldInstruction` subclasses).
- New `FetchConnectionDetailsInstruction : YieldInstruction` adapts the underlying `Task<ConnectionDetails>` and exposes `Result` / `Exception`. The `ITokenSource` interfaces stay `Task`-based because the HTTP work uses `HttpClient` natively; only the component layer is converted.
- Update the Meet sample's `ConnectToRoom` to `yield return fetch;` and read `fetch.IsError` / `fetch.Result` instead of polling `task.IsCompleted`.

## Test plan
- [ ] `Samples~/Meet` builds and runs in Unity 2022.3 / 6000.0.
- [ ] Start Call → fetch succeeds → room connects (sandbox token source).
- [ ] Endpoint with bad URL → `fetch.IsError` is true and the error is logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)