### PR TITLE
Fix WebCamTexture orientation on the wire

### DIFF
--- a/Runtime/Scripts/Internal/TaskYieldInstruction.cs.meta
+++ b/Runtime/Scripts/Internal/TaskYieldInstruction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2826c9df3de89432494d893a4ac353e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/WebCameraSource.cs
+++ b/Runtime/Scripts/WebCameraSource.cs
@@ -28,10 +28,12 @@ namespace LiveKit
         {
             switch (CamTexture.videoRotationAngle)
             {
+                case 0: return VideoRotation._0;
                 case 90: return VideoRotation._90;
-                case 180: return VideoRotation._0;
+                case 180: return VideoRotation._180;
+                case 270: return VideoRotation._270;
             }
-            return VideoRotation._180;
+            return VideoRotation._0;
         }
 
         public WebCameraSource(WebCamTexture texture, VideoBufferType bufferType = VideoBufferType.Rgba) : base(VideoStreamSource.Texture, bufferType)
@@ -81,8 +83,13 @@ namespace LiveKit
             }
 
             CamTexture.GetPixels32(_readBuffer);
-            MemoryMarshal.Cast<Color32, byte>(_readBuffer)
-                .CopyTo(_captureBuffer.AsSpan());
+            // GetPixels32 returns rows bottom-up; WebRTC expects top-down. Flip while copying.
+            var src = MemoryMarshal.Cast<Color32, byte>(_readBuffer);
+            var dst = _captureBuffer.AsSpan();
+            int rowBytes = width * GetStrideForBuffer(_bufferType);
+            for (int y = 0; y < height; y++)
+                src.Slice(y * rowBytes, rowBytes)
+                   .CopyTo(dst.Slice((height - 1 - y) * rowBytes, rowBytes));
 
             _requestPending = true;
 


### PR DESCRIPTION
## Summary

Fixes two related bugs that caused remote participants to see local video at the wrong orientation:

- **Rotation passthrough.** `WebCameraSource.GetVideoRotation` was mismapping cases (`0→_180`, `180→_0`, `270→_180`). Android front cam in portrait reports `videoRotationAngle == 270`, so remotes saw the stream 90° off. Replaced with a straight passthrough across all four angles.
- **Buffer Y-flip.** `GetPixels32` returns rows bottom-up but WebRTC expects top-down, so the buffer was being sent vertically flipped. The previous `0→_180` mapping was masking this on desktop (180° rotation visually approximates a Y-flip on roughly-symmetric subjects), but it was never actually correct. Flip rows during the buffer copy.

Also includes a missing `.meta` file for `TaskYieldInstruction.cs`.

## Test plan

- [x] Android front cam, portrait — remote sees upright
- [x] Android back cam, portrait — remote sees upright
- [x] iOS front cam, portrait — remote sees upright
- [x] iOS back cam, portrait — remote sees upright
- [x] iOS landscape (front + back) — remote sees upright (this is the path the old broken mapping happened to compensate for; verify the passthrough is correct here)
- [x] Editor / macOS desktop webcam — remote sees upright (no longer relying on the `_180` hack to mask the Y-flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)