### PR TITLE
Fix leaked textures on resolution change and quit

### DIFF
--- a/Runtime/Scripts/CameraVideoSource.cs
+++ b/Runtime/Scripts/CameraVideoSource.cs
@@ -51,6 +51,17 @@ namespace LiveKit
             ClearRenderTexture();
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && _renderTexture != null)
+            {
+                _renderTexture.Release();
+                UnityEngine.Object.Destroy(_renderTexture);
+                _renderTexture = null;
+            }
+            base.Dispose(disposing);
+        }
+
         private void ClearRenderTexture()
         {
             if (_renderTexture)
@@ -71,6 +82,18 @@ namespace LiveKit
             {
                 if (_renderTexture == null || _renderTexture.width != GetWidth() || _renderTexture.height != GetHeight())
                 {
+                    // Free previously allocated GPU/native resources before reallocating;
+                    // otherwise the old textures and NativeArray leak on every resolution change.
+                    if (_renderTexture != null)
+                    {
+                        _renderTexture.Release();
+                        UnityEngine.Object.Destroy(_renderTexture);
+                    }
+                    if (_previewTexture != null)
+                        UnityEngine.Object.Destroy(_previewTexture);
+                    if (_captureBuffer.IsCreated)
+                        _captureBuffer.Dispose();
+
                     var targetFormat = Utils.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
                     var compatibleFormat = SystemInfo.GetCompatibleFormat(targetFormat, FormatUsage.ReadPixels);
                     _textureFormat = GraphicsFormatUtility.GetTextureFormat(compatibleFormat);

--- a/Runtime/Scripts/ScreenVideoSource.cs
+++ b/Runtime/Scripts/ScreenVideoSource.cs
@@ -45,6 +45,17 @@ namespace LiveKit
             ClearRenderTexture();
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && _renderTexture != null)
+            {
+                _renderTexture.Release();
+                UnityEngine.Object.Destroy(_renderTexture);
+                _renderTexture = null;
+            }
+            base.Dispose(disposing);
+        }
+
         private void ClearRenderTexture()
         {
             if (_renderTexture)
@@ -65,6 +76,18 @@ namespace LiveKit
             {
                 if (_renderTexture == null || _renderTexture.width != GetWidth() || _renderTexture.height != GetHeight())
                 {
+                    // Free previously allocated GPU/native resources before reallocating;
+                    // otherwise the old textures and NativeArray leak on every resolution change.
+                    if (_renderTexture != null)
+                    {
+                        _renderTexture.Release();
+                        UnityEngine.Object.Destroy(_renderTexture);
+                    }
+                    if (_previewTexture != null)
+                        UnityEngine.Object.Destroy(_previewTexture);
+                    if (_captureBuffer.IsCreated)
+                        _captureBuffer.Dispose();
+
                     var targetFormat = Utils.GetSupportedGraphicsFormat(SystemInfo.graphicsDeviceType);
                     var compatibleFormat = SystemInfo.GetCompatibleFormat(targetFormat, FormatUsage.ReadPixels);
                     _textureFormat = GraphicsFormatUtility.GetTextureFormat(compatibleFormat);

--- a/Runtime/Scripts/WebCameraSource.cs
+++ b/Runtime/Scripts/WebCameraSource.cs
@@ -47,6 +47,17 @@ namespace LiveKit
             Dispose(false);
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (_tempTexture != null)
+            {
+                _tempTexture.Release();
+                UnityEngine.Object.Destroy(_tempTexture);
+                _tempTexture = null;
+            }
+            base.Dispose(disposing);
+        }
+
         private Color32[] _readBuffer;
 
         // Read the texture data into a native array asynchronously
@@ -64,7 +75,16 @@ namespace LiveKit
                 _previewTexture.width != width ||
                 _previewTexture.height != height)
             {
-                // Required when using Allocator.Persistent
+                // Free previously allocated GPU/native resources before reallocating;
+                // otherwise the old textures and NativeArray leak on every resolution change.
+                if (_previewTexture != null)
+                    UnityEngine.Object.Destroy(_previewTexture);
+                if (_tempTexture != null)
+                {
+                    _tempTexture.Release();
+                    UnityEngine.Object.Destroy(_tempTexture);
+                    _tempTexture = null;
+                }
                 if (_captureBuffer.IsCreated)
                     _captureBuffer.Dispose();
 

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -81,6 +81,14 @@ public class MeetManager : MonoBehaviour
 
     private void OnDestroy()
     {
+        // Without this, scene change / app quit while connected leaves all tracks,
+        // streams, and their backing GPU/native resources allocated.
+        if (_room != null)
+        {
+            _room.Disconnect();
+            _room = null;
+        }
+        CleanUpAllTracks();
         _webCamTexture?.Stop();
     }
 


### PR DESCRIPTION
## Summary

Fixes texture/buffer leaks in the video source paths and on Meet sample shutdown.

- **`WebCameraSource`, `CameraVideoSource`, `ScreenVideoSource`**: each one reallocated `RenderTexture` / `Texture2D` / `NativeArray<byte>` when the source resolution changed, but did not release/destroy/dispose the previous instances first. The old GPU and native allocations leaked on every resize.
- **`WebCameraSource.Dispose`**: previously did not release `_tempTexture` (the parent `RtcVideoSource.Dispose` only frees `_previewTexture` and `_captureBuffer`). Added an override.
- **`CameraVideoSource.Dispose` / `ScreenVideoSource.Dispose`**: previously had a `ClearRenderTexture()` that only called `Release()` (no `Object.Destroy`), and was not invoked from `Dispose`. Added overrides that fully release + destroy the `_renderTexture` when called from user code.
- **`MeetManager.OnDestroy`**: only stopped the `WebCamTexture`. If the scene was destroyed (or app quit) while still in a call, every track, stream, and tile remained allocated. Now disconnects the room and runs `CleanUpAllTracks()`.

These bugs primarily compound on resolution changes (camera flips, screen resizes, orientation changes) and on app/scene shutdown — they don't fully explain steady-state per-frame growth, but they do contribute to long-running session bloat.

## Test plan

- [ ] Manual: open Meet sample, start a call, toggle camera on/off several times, check Memory Profiler — RT/Tex2D count should stay flat across resolution changes
- [ ] Manual: open Meet sample, start a call, close the scene/quit — confirm Unity does not log "leaked Object" warnings for textures or video sources
- [ ] Existing EditMode/PlayMode tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)