### PR TITLE
Release FFI handles on Room.Disconnect

### DIFF
--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -624,7 +624,7 @@ namespace LiveKit
 
             IsError = !string.IsNullOrEmpty(e.Error);
             IsDone = true;
-            var publication = new LocalTrackPublication(e.Publication.Info);
+            var publication = new LocalTrackPublication(e.Publication.Info, FfiHandle.FromOwnedHandle(e.Publication.Handle));
             publication.UpdateTrack(_localTrack as Track);
             _localTrack.UpdateSid(publication.Sid);
             _internalTracks.Add(e.Publication.Info.Sid, publication);

--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -55,6 +55,14 @@ namespace LiveKit
         {
             TrackUnpublished?.Invoke(publication);
         }
+
+        internal void DisposeHandles()
+        {
+            foreach (var pub in _tracks.Values)
+                pub.DisposeHandles();
+            _tracks.Clear();
+            Handle?.Dispose();
+        }
     }
 
     public sealed class LocalParticipant : Participant

--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -106,9 +106,10 @@ namespace LiveKit
         }
     }
 
-    public class Room
+    public class Room : IDisposable
     {
         internal FfiHandle RoomHandle = null;
+        private bool _disposed = false;
         private readonly Dictionary<string, RemoteParticipant> _participants = new();
         private StreamHandlerRegistry _streamHandlers = new();
 
@@ -183,7 +184,7 @@ namespace LiveKit
 
         public void Disconnect()
         {
-            if (this.RoomHandle == null)
+            if (_disposed || RoomHandle == null)
                 return;
             var (response, _) = FFIBridge.Instance.SendDisconnectRequest(this);
             using (response)
@@ -191,6 +192,38 @@ namespace LiveKit
                 Utils.Debug($"Disconnect.... {RoomHandle}");
                 Utils.Debug($"Disconnect response.... {response}");
             }
+            // Release the Rust-side room synchronously. Without this the FfiRoom
+            // (peer connection, signaling client, libwebrtc state) lingers in the
+            // FFI handle table until the SafeHandle finalizer runs.
+            Cleanup();
+        }
+
+        public void Dispose()
+        {
+            Disconnect();
+            GC.SuppressFinalize(this);
+        }
+
+        private void Cleanup()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            FfiClient.Instance.RoomEventReceived -= OnEventReceived;
+            FfiClient.Instance.RpcMethodInvocationReceived -= OnRpcMethodInvocationReceived;
+            FfiClient.Instance.DisconnectReceived -= OnDisconnectReceived;
+
+            // Participant + track + publication FFI handles are independent entries in the
+            // Rust handle table — dropping the room handle alone does not cascade to them, so
+            // they would otherwise linger until C# GC finalizes each SafeHandle.
+            LocalParticipant?.DisposeHandles();
+            foreach (var p in _participants.Values)
+                p.DisposeHandles();
+            _participants.Clear();
+
+            RoomHandle?.Dispose();
+            RoomHandle = null;
         }
 
         /// <summary>
@@ -266,6 +299,10 @@ namespace LiveKit
 
         internal void OnEventReceived(RoomEvent e)
         {
+            // After Cleanup() the handle is null but late events may still flow
+            // through the FfiClient before the unsubscribe fully takes effect.
+            if (RoomHandle == null)
+                return;
             if (e.RoomHandle != (ulong)RoomHandle.DangerousGetHandle())
                 return;
 
@@ -564,8 +601,7 @@ namespace LiveKit
 
         private void OnDisconnect()
         {
-            FfiClient.Instance.RoomEventReceived -= OnEventReceived;
-            FfiClient.Instance.RpcMethodInvocationReceived -= OnRpcMethodInvocationReceived;
+            Cleanup();
         }
 
         internal RemoteParticipant CreateRemoteParticipantWithTracks(ConnectCallback.Types.ParticipantWithTracks item)

--- a/Runtime/Scripts/RtcAudioSource.cs
+++ b/Runtime/Scripts/RtcAudioSource.cs
@@ -294,6 +294,7 @@ namespace LiveKit
                 }
                 _pendingFrameData.Clear();
             }
+            Handle?.Dispose();
             _disposed = true;
             Utils.Debug($"{DebugTag} disposed");
         }

--- a/Runtime/Scripts/RtcVideoSource.cs
+++ b/Runtime/Scripts/RtcVideoSource.cs
@@ -211,6 +211,7 @@ namespace LiveKit
                 Debug.Log("Disposing capture buffer");
                 _captureBuffer.Dispose();
             }
+            Handle?.Dispose();
             _disposed = true;
         }
 

--- a/Runtime/Scripts/Track.cs
+++ b/Runtime/Scripts/Track.cs
@@ -108,6 +108,11 @@ namespace LiveKit
         {
             _info.Muted = muted;
         }
+
+        internal void DisposeHandles()
+        {
+            Handle?.Dispose();
+        }
     }
 
     public sealed class LocalAudioTrack : Track, ILocalTrack, IAudioTrack

--- a/Runtime/Scripts/TrackPublication.cs
+++ b/Runtime/Scripts/TrackPublication.cs
@@ -40,6 +40,11 @@ namespace LiveKit
             _info.Muted = muted;
             Track?.UpdateMuted(muted);
         }
+
+        internal virtual void DisposeHandles()
+        {
+            Track?.DisposeHandles();
+        }
     }
 
     public sealed class RemoteTrackPublication : TrackPublication
@@ -52,6 +57,12 @@ namespace LiveKit
         internal RemoteTrackPublication(TrackPublicationInfo info, FfiHandle handle) : base(info)
         {
             Handle = handle;
+        }
+
+        internal override void DisposeHandles()
+        {
+            base.DisposeHandles();
+            Handle?.Dispose();
         }
 
         public void SetSubscribed(bool subscribed)

--- a/Runtime/Scripts/TrackPublication.cs
+++ b/Runtime/Scripts/TrackPublication.cs
@@ -96,8 +96,17 @@ namespace LiveKit
     {
         public new ILocalTrack Track => base.Track as ILocalTrack;
 
-        internal LocalTrackPublication(TrackPublicationInfo info) : base(info)
+        private FfiHandle Handle;
+
+        internal LocalTrackPublication(TrackPublicationInfo info, FfiHandle handle) : base(info)
         {
+            Handle = handle;
+        }
+
+        internal override void DisposeHandles()
+        {
+            base.DisposeHandles();
+            Handle?.Dispose();
         }
     }
 }

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -90,6 +90,7 @@ public class MeetManager : MonoBehaviour
         }
         CleanUpAllTracks();
         _webCamTexture?.Stop();
+        _room?.Disconnect();
     }
 
     #endregion


### PR DESCRIPTION
## Summary
Room never disposed its FFI handles on disconnect — the Rust-side room (peer connection, signaling, libwebrtc state) plus every wrapped participant, publication, track, and Rtc source lingered until C# GC eventually finalized each SafeHandle. On a connect / hold / disconnect cycle the FFI handle table grew by ~10 entries that were never freed within the session.

## Dependency
~Depends on Rust fix: https://github.com/livekit/rust-sdks/pull/1066~
~Fails without Rust fix: https://github.com/livekit/client-sdk-unity/actions/runs/25560080036?pr=278~
~Runs green with Rust fix: https://github.com/livekit/client-sdk-unity/actions/runs/25562060656?pr=278~

=> Fix was also found and commited by DZ in this PR: https://github.com/livekit/rust-sdks/pull/1069
It is in FFI release 0.12.55. With that version, the tests also run green.

## Changes
- **Release Room FFI handles on disconnect** — `Room` is now `IDisposable`. `Disconnect()` and the server-initiated `Disconnected` event both run a single idempotent `Cleanup()` that unsubscribes from `FfiClient` events and walks `LocalParticipant` + `RemoteParticipants`, disposing each participant + its publications + the publications' tracks before disposing `RoomHandle` itself. `MeetManager.OnDestroy` also disconnects so scene change / quit releases the handles.
- **Release local publication and Rtc source FFI handles on cleanup** — `LocalTrackPublication` now wraps the FFI handle returned from `PublishTrackCallback` and disposes it through the same cascade. `RtcVideoSource` and `RtcAudioSource` `Dispose(bool)` overrides now dispose their `Handle`.

## Test plan
- [x] FFI handle table returns to baseline after connect / hold / disconnect with mic + camera published and a remote with mic + camera subscribed (verified via a temporary Rust diagnostic).
- [x] Verified each commit compiles individually (bisectable).
- [x] iOS build succeeds; tested on device.

### Before

Before connecting:
`LiveKit: [ffi-handles-diag] total=0 rooms=0 participants=0 tracks=0 publications=0 video_sources=0 audio_sources=0 video_streams=0 audio_streams=0 audio_frames=0 data_buffers=0 byte_boxes=0 other=0`

During connection:
`LiveKit: [ffi-handles-diag] total=10 rooms=1 participants=2 tracks=2 publications=2 video_sources=0 audio_sources=0 video_streams=1 audio_streams=1 audio_frames=0 data_buffers=0 byte_boxes=1 other=0`

After disconnecting:
`LiveKit: [ffi-handles-diag] total=8 rooms=1 participants=2 tracks=0 publications=2 video_sources=0 audio_sources=0 video_streams=0 audio_streams=0 audio_frames=0 data_buffers=0 byte_boxes=1 other=2`

Disconnected idle at 5 minutes:
`LiveKit: [ffi-handles-diag] total=1 rooms=0 participants=0 tracks=0 publications=0 video_sources=0 audio_sources=0 video_streams=0 audio_streams=0 audio_frames=0 data_buffers=0 byte_boxes=1 other=0`
