### PR TITLE
Init token source component in awake

### DIFF
--- a/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
@@ -24,7 +24,7 @@ namespace LiveKit
 
         ITokenSource _tokenSource;
 
-        public void Start()
+        public void Awake()
         {
             if (_config == null)
                 throw new InvalidOperationException("Token source configuration was not provided");


### PR DESCRIPTION
### Background

TokenSourceComponent would check its TokenSource config in Start and other scripts that rely on it in Start would sometimes call it earlier than it is set up.

### Changes

What did you do?

- Move init into Awake function.