### PR TITLE
Meet: Android foreground service to survive screen lock

### DIFF
--- a/Samples~/Meet/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Samples~/Meet/Assets/Plugins/Android/AndroidManifest.xml
@@ -7,6 +7,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application>
         <activity android:name="com.unity3d.player.UnityPlayerActivity"
@@ -17,5 +21,11 @@
             </intent-filter>
             <meta-data android:name="unityplayer.UnityActivity" android:value="true" />
         </activity>
+
+        <service
+            android:name="io.livekit.unity.sample.LiveKitForegroundService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
     </application>
 </manifest>

--- a/Samples~/Meet/Assets/Plugins/Android/AndroidManifest.xml
+++ b/Samples~/Meet/Assets/Plugins/Android/AndroidManifest.xml
@@ -9,8 +9,6 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application>
         <activity android:name="com.unity3d.player.UnityPlayerActivity"

--- a/Samples~/Meet/Assets/Plugins/Android/LiveKitForegroundService.java
+++ b/Samples~/Meet/Assets/Plugins/Android/LiveKitForegroundService.java
@@ -1,0 +1,75 @@
+package io.livekit.unity.sample;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+
+public class LiveKitForegroundService extends Service {
+
+    private static final String CHANNEL_ID = "livekit_call";
+    private static final int NOTIFICATION_ID = 1701;
+
+    public static void start(Context context) {
+        Intent intent = new Intent(context, LiveKitForegroundService.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent);
+        } else {
+            context.startService(intent);
+        }
+    }
+
+    public static void stop(Context context) {
+        Intent intent = new Intent(context, LiveKitForegroundService.class);
+        context.stopService(intent);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        ensureChannel();
+        startForeground(NOTIFICATION_ID, buildNotification());
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_STICKY;
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    private void ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return;
+        NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm == null) return;
+        if (nm.getNotificationChannel(CHANNEL_ID) != null) return;
+        NotificationChannel channel = new NotificationChannel(
+                CHANNEL_ID,
+                "Active call",
+                NotificationManager.IMPORTANCE_LOW);
+        channel.setShowBadge(false);
+        nm.createNotificationChannel(channel);
+    }
+
+    private Notification buildNotification() {
+        Notification.Builder builder;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            builder = new Notification.Builder(this, CHANNEL_ID);
+        } else {
+            builder = new Notification.Builder(this);
+        }
+        return builder
+                .setContentTitle("LiveKit call")
+                .setContentText("Connected — running in the background")
+                .setSmallIcon(android.R.drawable.ic_menu_call)
+                .setOngoing(true)
+                .build();
+    }
+}

--- a/Samples~/Meet/Assets/Plugins/Android/LiveKitForegroundService.java.meta
+++ b/Samples~/Meet/Assets/Plugins/Android/LiveKitForegroundService.java.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 2e8637f804894af6829149cdf7053fbb
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/Meet/Assets/Runtime/AndroidBackgroundService.cs
+++ b/Samples~/Meet/Assets/Runtime/AndroidBackgroundService.cs
@@ -1,10 +1,11 @@
+#if UNITY_ANDROID && !UNITY_EDITOR
 using UnityEngine;
 
 /// <summary>
 /// Starts/stops an Android foreground service so the OS keeps the process out of Doze
 /// while the user is in a LiveKit call. Without it, the screen lock pauses the network
 /// long enough for the SDK to exhaust its 10 reconnect attempts and disconnect.
-/// No-op on all non-Android platforms.
+/// Call sites must guard with `#if UNITY_ANDROID && !UNITY_EDITOR`.
 /// </summary>
 public static class AndroidBackgroundService
 {
@@ -12,19 +13,14 @@ public static class AndroidBackgroundService
 
     public static void Start()
     {
-#if UNITY_ANDROID && !UNITY_EDITOR
         WithActivity((cls, activity) => cls.CallStatic("start", activity));
-#endif
     }
 
     public static void Stop()
     {
-#if UNITY_ANDROID && !UNITY_EDITOR
         WithActivity((cls, activity) => cls.CallStatic("stop", activity));
-#endif
     }
 
-#if UNITY_ANDROID && !UNITY_EDITOR
     private static void WithActivity(System.Action<AndroidJavaClass, AndroidJavaObject> body)
     {
         try
@@ -39,5 +35,5 @@ public static class AndroidBackgroundService
             Debug.LogWarning($"AndroidBackgroundService: {e.Message}");
         }
     }
-#endif
 }
+#endif

--- a/Samples~/Meet/Assets/Runtime/AndroidBackgroundService.cs
+++ b/Samples~/Meet/Assets/Runtime/AndroidBackgroundService.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+/// <summary>
+/// Starts/stops an Android foreground service so the OS keeps the process out of Doze
+/// while the user is in a LiveKit call. Without it, the screen lock pauses the network
+/// long enough for the SDK to exhaust its 10 reconnect attempts and disconnect.
+/// No-op on all non-Android platforms.
+/// </summary>
+public static class AndroidBackgroundService
+{
+    private const string ServiceClassName = "io.livekit.unity.sample.LiveKitForegroundService";
+
+    public static void Start()
+    {
+#if UNITY_ANDROID && !UNITY_EDITOR
+        WithActivity((cls, activity) => cls.CallStatic("start", activity));
+#endif
+    }
+
+    public static void Stop()
+    {
+#if UNITY_ANDROID && !UNITY_EDITOR
+        WithActivity((cls, activity) => cls.CallStatic("stop", activity));
+#endif
+    }
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+    private static void WithActivity(System.Action<AndroidJavaClass, AndroidJavaObject> body)
+    {
+        try
+        {
+            using var player = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+            using var activity = player.GetStatic<AndroidJavaObject>("currentActivity");
+            using var serviceClass = new AndroidJavaClass(ServiceClassName);
+            body(serviceClass, activity);
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogWarning($"AndroidBackgroundService: {e.Message}");
+        }
+    }
+#endif
+}

--- a/Samples~/Meet/Assets/Runtime/AndroidBackgroundService.cs.meta
+++ b/Samples~/Meet/Assets/Runtime/AndroidBackgroundService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 334ca55defd34c5f80afc91f2f03b352
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -90,6 +90,7 @@ public class MeetManager : MonoBehaviour
         }
         CleanUpAllTracks();
         _webCamTexture?.Stop();
+        AndroidBackgroundService.Stop();
     }
 
     #endregion
@@ -110,6 +111,7 @@ public class MeetManager : MonoBehaviour
         _room = null;
         _localId = null;
         buttonBar.SetConnected(false);
+        AndroidBackgroundService.Stop();
     }
 
     private void OnToggleCamera()
@@ -183,6 +185,7 @@ public class MeetManager : MonoBehaviour
         Debug.Log($"Connected to {_room.Name}");
         _localId = _room.LocalParticipant.Identity;
         buttonBar.SetConnected(true);
+        AndroidBackgroundService.Start();
 
         EnsureParticipantTile(_localId);
         foreach (var remote in _room.RemoteParticipants.Values)

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -90,7 +90,9 @@ public class MeetManager : MonoBehaviour
         }
         CleanUpAllTracks();
         _webCamTexture?.Stop();
+#if UNITY_ANDROID && !UNITY_EDITOR
         AndroidBackgroundService.Stop();
+#endif
     }
 
     #endregion
@@ -111,7 +113,9 @@ public class MeetManager : MonoBehaviour
         _room = null;
         _localId = null;
         buttonBar.SetConnected(false);
+#if UNITY_ANDROID && !UNITY_EDITOR
         AndroidBackgroundService.Stop();
+#endif
     }
 
     private void OnToggleCamera()
@@ -185,7 +189,9 @@ public class MeetManager : MonoBehaviour
         Debug.Log($"Connected to {_room.Name}");
         _localId = _room.LocalParticipant.Identity;
         buttonBar.SetConnected(true);
+#if UNITY_ANDROID && !UNITY_EDITOR
         AndroidBackgroundService.Start();
+#endif
 
         EnsureParticipantTile(_localId);
         foreach (var remote in _room.RemoteParticipants.Values)


### PR DESCRIPTION
## Summary

On Android, locking the screen / backgrounding the Meet app for ~50s causes the LiveKit SDK to exhaust its 10 reconnect attempts and emit `failed to reconnect to the livekit room`, leaving the room permanently disconnected. iOS suspends the whole process so its tokio reconnect loop is paused mid-flight and recovers on resume — Android does not get that for free; with Doze restricting the network, the loop runs at full speed against a dead socket and gives up.

This PR makes the Meet sample run a foreground service while a call is active so the OS keeps the process out of Doze and the network stays alive. iOS / desktop / editor are unaffected (call-site `#if UNITY_ANDROID && !UNITY_EDITOR` guards).

Changes:
- `Samples~/Meet/Assets/Plugins/Android/AndroidManifest.xml` — adds `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permissions and a `mediaPlayback` `<service>` entry.
- `Samples~/Meet/Assets/Plugins/Android/LiveKitForegroundService.java` — small foreground service that posts a low-importance ongoing notification.
- `Samples~/Meet/Assets/Runtime/AndroidBackgroundService.cs` — thin Android-only C# bridge with `Start()` / `Stop()`.
- `MeetManager.cs` — starts the service on a successful `Connect`, stops it on `OnEndCall` / `OnDestroy`.

## Test plan

- [x] Android device: connect to a room, lock the screen, wait > 1 minute, unlock — call still alive, no `restarting connection… attempt: N` log spam.
- [x] Android device: swipe app away — participant leaves the room within the LiveKit server timeout (~15–60s). This was already the pre-existing behaviour on `main` and is server-side timeout, not regressed by this PR.
- [x] iOS device: behaviour unchanged.
- [x] Editor / desktop: behaviour unchanged.

## Notes

- `POST_NOTIFICATIONS` is intentionally **not** declared — the foreground service runs without it; only the notification visibility is gated by it, and we never request it at runtime.
- The Java service is shipped at sample level rather than inside the SDK; if we'd rather have it ship to all consumers, it can move into the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)