### PR TITLE
Improve Android fix branch

### DIFF
--- a/Runtime/Scripts/Internal/FFIClients/FfiRequestExtensions.cs
+++ b/Runtime/Scripts/Internal/FFIClients/FfiRequestExtensions.cs
@@ -162,6 +162,12 @@ namespace LiveKit.Internal.FFIClients
                 case SetPlayoutDeviceRequest setPlayoutDeviceRequest:
                     ffiRequest.SetPlayoutDevice = setPlayoutDeviceRequest;
                     break;
+                case StartRecordingRequest startRecordingRequest:
+                    ffiRequest.StartRecording = startRecordingRequest;
+                    break;
+                case StopRecordingRequest stopRecordingRequest:
+                    ffiRequest.StopRecording = stopRecordingRequest;
+                    break;
                 case LocalTrackMuteRequest localTrackMuteRequest:
                     ffiRequest.LocalTrackMute = localTrackMuteRequest;
                     break;

--- a/Runtime/Scripts/PlatformAudio.cs
+++ b/Runtime/Scripts/PlatformAudio.cs
@@ -202,6 +202,7 @@ namespace LiveKit
                 throw new InvalidOperationException($"Recording device index {index} out of range (max: {recording.Count - 1})");
 
             var deviceId = recording[(int)index].Guid;
+
             // Note: On Android, devices don't have GUIDs - they're identified by index only.
             // Android also only reports a single "default" microphone because the system
             // automatically selects the best input source based on the audio mode.
@@ -222,6 +223,15 @@ namespace LiveKit
         /// </exception>
         public void SetRecordingDevice(string deviceId)
         {
+#if UNITY_IOS && !UNITY_EDITOR
+            // iOS exposes only one logical WebRTC recording device, and AudioDeviceIOS::RecordingDeviceName
+            // returns -1, so set_recording_device_by_guid in native code can never match and always
+            // returns "Device not found". Mic input routing on iOS is governed by AVAudioSession
+            // (configured via IOSAudioSessionHelper.LiveKit_ConfigureAudioSessionForVoIP), not by
+            // WebRTC device selection, so skipping the FFI call here is the correct behavior.
+            Utils.Debug($"PlatformAudio: skipping SetRecordingDevice on iOS (deviceId '{deviceId}'); input is governed by AVAudioSession");
+            return;
+#else
             using var request = FFIBridge.Instance.NewRequest<SetRecordingDeviceRequest>();
             request.request.PlatformAudioHandle = (ulong)Handle.DangerousGetHandle();
             request.request.DeviceId = deviceId;
@@ -233,17 +243,8 @@ namespace LiveKit
                 throw new InvalidOperationException($"Failed to set recording device: {res.SetRecordingDevice.Error}");
 
             Utils.Debug($"PlatformAudio: set recording device to {deviceId}");
+#endif
         }
-
-        /// <summary>
-        /// Sets the recording device (microphone) by GUID.
-        /// </summary>
-        /// <param name="guid">Device GUID from GetDevices().Recording[i].Guid</param>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if the device is not found or the operation failed.
-        /// </exception>
-        [Obsolete("Use SetRecordingDevice(string deviceId) instead")]
-        public void SetRecordingDeviceByGuid(string guid) => SetRecordingDevice(guid);
 
         /// <summary>
         /// Sets the playout device (speaker/headphones) by index.
@@ -265,6 +266,7 @@ namespace LiveKit
                 throw new InvalidOperationException($"Playout device index {index} out of range (max: {playout.Count - 1})");
 
             var deviceId = playout[(int)index].Guid;
+
             // Note: On Android, devices don't have GUIDs - they're identified by index only.
             // Android also only reports a single "default" device because audio routing
             // (speaker vs earpiece vs Bluetooth) is handled by the system via AudioManager,
@@ -286,6 +288,13 @@ namespace LiveKit
         /// </exception>
         public void SetPlayoutDevice(string deviceId)
         {
+#if UNITY_IOS && !UNITY_EDITOR
+            // Same iOS limitation as SetRecordingDevice: AudioDeviceIOS::PlayoutDeviceName returns -1,
+            // so set_playout_device_by_guid never matches. Speaker vs earpiece vs Bluetooth routing on
+            // iOS is governed by AVAudioSession, not by WebRTC device selection.
+            Utils.Debug($"PlatformAudio: skipping SetPlayoutDevice on iOS (deviceId '{deviceId}'); output is governed by AVAudioSession");
+            return;
+#else
             using var request = FFIBridge.Instance.NewRequest<SetPlayoutDeviceRequest>();
             request.request.PlatformAudioHandle = (ulong)Handle.DangerousGetHandle();
             request.request.DeviceId = deviceId;
@@ -297,17 +306,8 @@ namespace LiveKit
                 throw new InvalidOperationException($"Failed to set playout device: {res.SetPlayoutDevice.Error}");
 
             Utils.Debug($"PlatformAudio: set playout device to {deviceId}");
+#endif
         }
-
-        /// <summary>
-        /// Sets the playout device (speaker/headphones) by GUID.
-        /// </summary>
-        /// <param name="guid">Device GUID from GetDevices().Playout[i].Guid</param>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if the device is not found or the operation failed.
-        /// </exception>
-        [Obsolete("Use SetPlayoutDevice(string deviceId) instead")]
-        public void SetPlayoutDeviceByGuid(string guid) => SetPlayoutDevice(guid);
 
         /// <summary>
         /// Starts recording from the microphone.

--- a/Runtime/Scripts/PlatformAudio.cs
+++ b/Runtime/Scripts/PlatformAudio.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using LiveKit.Proto;
 using LiveKit.Internal;
 using LiveKit.Internal.FFIClients.Requests;
+
+#if PLATFORM_ANDROID
+using UnityEngine.Android;
+#endif
 
 namespace LiveKit
 {
@@ -319,8 +324,32 @@ namespace LiveKit
         /// <exception cref="InvalidOperationException">
         /// Thrown if the operation failed.
         /// </exception>
-        public void StartRecording()
+        public IEnumerator StartRecording()
         {
+#if PLATFORM_ANDROID
+            if (!Permission.HasUserAuthorizedPermission(Permission.Microphone))
+            {
+                // Fire the system permission dialog and yield until the user resolves it.
+                // PermissionCallbacks delivers the result asynchronously from the Android OS;
+                // we poll the captured flag from this coroutine until one of the callbacks
+                // sets it. Without this gate, the WebRTC Android ADM would crash the process
+                // when AudioRecord fails to open due to the missing permission.
+                bool? granted = null;
+                var callbacks = new PermissionCallbacks();
+                callbacks.PermissionGranted += _ => granted = true;
+                callbacks.PermissionDenied += _ => granted = false;
+                callbacks.PermissionDeniedAndDontAskAgain += _ => granted = false;
+                Permission.RequestUserPermission(Permission.Microphone, callbacks);
+
+                while (granted == null)
+                    yield return null;
+
+                if (granted == false)
+                    throw new InvalidOperationException(
+                        "Microphone permission denied by user; cannot start recording.");
+            }
+#endif
+
             using var request = FFIBridge.Instance.NewRequest<StartRecordingRequest>();
             request.request.PlatformAudioHandle = (ulong)Handle.DangerousGetHandle();
 
@@ -331,6 +360,11 @@ namespace LiveKit
                 throw new InvalidOperationException($"Failed to start recording: {res.StartRecording.Error}");
 
             Utils.Debug("PlatformAudio: started recording");
+
+            // Ensures this method is always a valid iterator even when the PLATFORM_ANDROID
+            // branch is compiled out (no `yield return` would otherwise be reachable on
+            // non-Android builds, which is a compile error for IEnumerator-returning methods).
+            yield break;
         }
 
         /// <summary>

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -536,14 +536,11 @@ public class MeetManager : MonoBehaviour
         Debug.Log("Publishing microphone using PlatformAudio (ADM)");
 
         // Start recording (in case it was stopped by a previous mute).
-        // This turns on the privacy indicator on macOS/iOS.
-        try
+        // This turns on the privacy indicator on macOS/iOS. On Android this also
+        // awaits the RECORD_AUDIO runtime permission dialog if not yet granted.
+        if (_platformAudio != null)
         {
-            _platformAudio?.StartRecording();
-        }
-        catch (System.Exception e)
-        {
-            Debug.LogWarning($"Failed to start recording (may already be started): {e.Message}");
+            yield return _platformAudio.StartRecording();
         }
 
         var audioOptions = new AudioProcessingOptions


### PR DESCRIPTION
### Background

iOS does not offer to chose the output device via the WebRTC ADM. We have to skip the selection entirely it seems.

```
Routing is controlled by AVAudioSession:

Skip SetRecordingDevice / SetPlayoutDevice entirely. iOS only ever has one logical WebRTC device, and the
actual mic/speaker selection is done by AVAudioSession (which IOSAudioSessionHelper.LiveKit_ConfigureAudioSessionForVoIP() already configures in
your constructor)
```

Also on Android asks for microphone permission before starting the PlatformAudio

### Changes

- Skip SetRecordingDevice / SetPlayoutDevice entirely
- Add missing inject for `SetRecordingDevice` and `SetPlayoutDevice`
- StartRecording is now a coroutine first asking for microphone permission on Android