### PR TITLE
Use dev server action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,24 +104,10 @@ jobs:
           shopt -s dotglob extglob
           mv !(root) root/
       # Required for E2E tests
-      - name: Install LiveKit Server
-        run: curl -sSL https://get.livekit.io | bash
       - name: Run LiveKit Server
-        env:
-          # TODO: once data tracks is enabled by default in a subsequent SFU release, remove this.
-          LIVEKIT_CONFIG: "enable_data_tracks: true"
-        run: livekit-server --dev &
-      - name: Wait for LiveKit Server
-        run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:7880 > /dev/null 2>&1; then
-              echo "LiveKit server is ready"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "LiveKit server failed to start within 30s"
-          exit 1
+        uses: livekit/dev-server-action@61e2b4dcb170dd3591e0c9b0db3c3fe5db93b500
+        with:
+          github-token: ${{ github.token }}
       - name: Run Tests
         uses: game-ci/unity-test-runner@v4
         id: testRunner


### PR DESCRIPTION
Uses [livekit/dev-server-action](https://github.com/livekit/dev-server-action) to run SFU for end-to-end testing.

Follow-up: setup matrix to also run E2E tests on macOS and Windows (action supports installing server for each platform).