### PR TITLE
Add PlayMode tests for PublishData size limits

### DIFF
--- a/Tests/PlayMode/PublishDataTests.cs
+++ b/Tests/PlayMode/PublishDataTests.cs
@@ -1,0 +1,84 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using LiveKit.PlayModeTests.Utils;
+
+namespace LiveKit.PlayModeTests
+{
+    // Probes the server-side size limit on LocalParticipant.PublishData. The C# API is
+    // fire-and-forget (no callback), so the only observable signal is whether the
+    // subscriber's DataReceived event fires within a timeout. The SFU data path may
+    // not be ready immediately after connect, so we retry publishing on an interval.
+    public class PublishDataTests
+    {
+        [UnityTest, Category("E2E")]
+        public IEnumerator Small_1KiB_Arrives()
+        {
+            yield return RunSizeProbe(1024, shouldArrive: true);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator At_15KiB_Arrives()
+        {
+            yield return RunSizeProbe(15 * 1024, shouldArrive: true);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator Above_64KiB_DoesNotArrive()
+        {
+            yield return RunSizeProbe(65 * 1024, shouldArrive: false);
+        }
+
+        private static IEnumerator RunSizeProbe(int payloadBytes, bool shouldArrive)
+        {
+            var publisher = TestRoomContext.ConnectionOptions.Default;
+            publisher.Identity = "publisher";
+            var subscriber = TestRoomContext.ConnectionOptions.Default;
+            subscriber.Identity = "subscriber";
+
+            using var context = new TestRoomContext(new[] { publisher, subscriber });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError);
+
+            var publisherRoom = context.Rooms[0];
+            var subscriberRoom = context.Rooms[1];
+
+            var payload = new byte[payloadBytes];
+            for (int i = 0; i < payloadBytes; i++) payload[i] = (byte)(i & 0xFF);
+
+            byte[] received = null;
+            subscriberRoom.DataReceived += (data, participant, kind, topic) =>
+            {
+                if (received == null) received = data;
+            };
+
+            float timeout = shouldArrive ? 5f : 3f;
+            float start = Time.realtimeSinceStartup;
+            float lastPublish = -1f;
+            const float interval = 0.2f;
+            while (received == null && Time.realtimeSinceStartup - start < timeout)
+            {
+                if (Time.realtimeSinceStartup - lastPublish >= interval)
+                {
+                    publisherRoom.LocalParticipant.PublishData(payload);
+                    lastPublish = Time.realtimeSinceStartup;
+                }
+                yield return null;
+            }
+
+            if (shouldArrive)
+            {
+                Assert.IsNotNull(received,
+                    $"Expected {payloadBytes}-byte payload to arrive within {timeout}s");
+                Assert.AreEqual(payloadBytes, received.Length, "Received payload length mismatch");
+                CollectionAssert.AreEqual(payload, received, "Received payload contents mismatch");
+            }
+            else
+            {
+                Assert.IsNull(received,
+                    $"Expected {payloadBytes}-byte payload to be dropped, but it arrived ({received?.Length} bytes)");
+            }
+        }
+    }
+}

--- a/Tests/PlayMode/PublishDataTests.cs.meta
+++ b/Tests/PlayMode/PublishDataTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ae5903661a1f4b5fbb7f64e0ff47db2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- `LocalParticipant.PublishData` is fire-and-forget — the C# API exposes no callback or instruction, so server-side drops of oversized packets are silent.
- Adds three PlayMode E2E tests probing the boundary by publishing payloads of varying sizes between two participants and observing the subscriber's `DataReceived` event.
- Verified against `livekit-server` 1.12.0:
  - **1 KiB** → arrives intact (length + bytes asserted)
  - **15 KiB** → arrives intact (length + bytes asserted)
  - **65 KiB** → silently dropped (assertion: `received == null` after retries within timeout)

The retry-on-200ms-interval pattern mirrors `DataTrackTests.cs` and guards against SFU warm-up flakiness where early publishes can be dropped before the data channel is ready.

## Test plan

- [x] Start `livekit-server --dev` locally
- [x] Run `Scripts~/run_unity.sh test -m PlayMode -f PublishDataTests`
- [x] All three tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)