### PR TITLE
Stage 3: IUniTaskAsyncEnumerable adapter for incremental byte/text streams

### DIFF
--- a/Runtime/Scripts/AssemblyInfo.cs
+++ b/Runtime/Scripts/AssemblyInfo.cs
@@ -2,3 +2,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("EditModeTests")]
 [assembly: InternalsVisibleTo("PlayModeTests")]
+[assembly: InternalsVisibleTo("PlayModeTests.UniTask")]

--- a/Runtime/Scripts/DataStream.cs
+++ b/Runtime/Scripts/DataStream.cs
@@ -95,7 +95,13 @@ namespace LiveKit
         /// </summary>
         public bool IsError => Error != null;
 
-        protected TContent LatestChunk
+        /// <summary>
+        /// The chunk from the most recent completed read. Throws the captured
+        /// <see cref="StreamError"/> if the last read errored. Public so the optional
+        /// UniTask async-enumerable adapter can read it generically; the typed
+        /// <c>Bytes</c>/<c>Text</c> accessors on the concrete readers delegate here.
+        /// </summary>
+        public TContent LatestChunk
         {
             get
             {

--- a/Runtime/Scripts/Internal/YieldInstruction.cs
+++ b/Runtime/Scripts/Internal/YieldInstruction.cs
@@ -115,10 +115,16 @@ namespace LiveKit
             }
         }
 
-        internal bool IsCurrentReadDone
+        /// <summary>
+        /// True once a chunk is ready for the current read (before <see cref="Reset"/> is
+        /// called for the next one). Public getter mirrors the sibling
+        /// <c>DataTrack.ReadFrameInstruction.IsCurrentReadDone</c>; the setter stays internal
+        /// because only the SDK's stream readers advance this state.
+        /// </summary>
+        public bool IsCurrentReadDone
         {
             get => _isCurrentReadDone;
-            set
+            internal set
             {
                 _isCurrentReadDone = value;
                 if (value) InvokeContinuation();

--- a/Runtime/Scripts/UniTask/StreamReaderUniTaskExtensions.cs
+++ b/Runtime/Scripts/UniTask/StreamReaderUniTaskExtensions.cs
@@ -1,0 +1,79 @@
+#if LIVEKIT_UNITASK
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks.Linq;
+
+namespace LiveKit
+{
+    /// <summary>
+    /// Exposes the SDK's incremental stream readers as <see cref="IUniTaskAsyncEnumerable{T}"/>
+    /// so chunks can be consumed with <c>await foreach</c>. Available only when the
+    /// <c>com.cysharp.unitask</c> package is installed (gated by <c>LIVEKIT_UNITASK</c>).
+    /// </summary>
+    public static class StreamReaderUniTaskExtensions
+    {
+        /// <summary>
+        /// Adapts an incremental stream read into an async sequence of chunks. Works for both
+        /// <see cref="ByteStreamReader.ReadIncrementalInstruction"/> (<c>byte[]</c>) and
+        /// <see cref="TextStreamReader.ReadIncrementalInstruction"/> (<c>string</c>).
+        /// </summary>
+        /// <remarks>
+        /// Iteration ends when the stream reaches end-of-stream. If the stream ends with an
+        /// error, the enumerable throws that <see cref="StreamError"/> (idiomatic for
+        /// <c>await foreach</c>; this is the one place the UniTask surface throws rather than
+        /// exposing <c>IsError</c>). Cancellation (via the token or the enumerator) surfaces as
+        /// <see cref="System.OperationCanceledException"/> with abandon-awaiter semantics — the
+        /// underlying FFI read is not cancelled on the wire.
+        ///
+        /// Like the coroutine consumer, this delivers the current chunk on the iteration where
+        /// end-of-stream is also observed, then stops. Chunks buffered <em>beyond</em> the
+        /// current one when end-of-stream arrives are not drainable — a pre-existing limitation
+        /// of the reader (its <c>Reset()</c> is disallowed past end-of-stream), not specific to
+        /// this adapter.
+        /// </remarks>
+        public static IUniTaskAsyncEnumerable<TChunk> AsAsyncEnumerable<TChunk>(
+            this ReadIncrementalInstructionBase<TChunk> instruction,
+            CancellationToken cancellationToken = default)
+        {
+            if (instruction == null) throw new System.ArgumentNullException(nameof(instruction));
+
+            return UniTaskAsyncEnumerable.Create<TChunk>(async (writer, token) =>
+            {
+                // The enumerator hands us its own token; honor both it and the caller's.
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(token, cancellationToken);
+                var ct = linked.Token;
+
+                while (true)
+                {
+                    // Completes when a chunk is ready (IsCurrentReadDone) or the stream ends (IsEos).
+                    await instruction.AsUniTask(ct);
+
+                    if (instruction.IsCurrentReadDone)
+                    {
+                        var chunk = instruction.LatestChunk;
+                        await writer.YieldAsync(chunk);
+
+                        // Re-check IsEos AFTER yielding: end-of-stream may have arrived while
+                        // the consumer was suspended. Reset() throws once IsEos is set, so this
+                        // re-check (not a value captured before the yield) is what keeps the
+                        // loop safe — mirroring the coroutine consumer's "if (IsEos) break;
+                        // else Reset()" ordering.
+                        if (instruction.IsEos)
+                        {
+                            if (instruction.IsError) throw instruction.Error;
+                            return;
+                        }
+
+                        instruction.Reset();
+                        continue;
+                    }
+
+                    // Not IsCurrentReadDone => end-of-stream with nothing left to read.
+                    if (instruction.IsError) throw instruction.Error;
+                    return;
+                }
+            });
+        }
+    }
+}
+#endif

--- a/Runtime/Scripts/UniTask/StreamReaderUniTaskExtensions.cs.meta
+++ b/Runtime/Scripts/UniTask/StreamReaderUniTaskExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba02c0c61aa014db28635be5e1cf6e64
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/UniTask/livekit.unity.Runtime.UniTask.asmdef
+++ b/Runtime/Scripts/UniTask/livekit.unity.Runtime.UniTask.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "LiveKit.UniTaskExtensions",
     "references": [
         "LiveKit",
-        "UniTask"
+        "UniTask",
+        "UniTask.Linq"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/PlayMode/UniTask/LiveKit.PlayModeTests.UniTask.asmdef
+++ b/Tests/PlayMode/UniTask/LiveKit.PlayModeTests.UniTask.asmdef
@@ -6,7 +6,8 @@
         "UnityEditor.TestRunner",
         "LiveKit",
         "LiveKit.UniTask",
-        "UniTask"
+        "UniTask",
+        "UniTask.Linq"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/PlayMode/UniTask/StreamUniTaskTests.cs
+++ b/Tests/PlayMode/UniTask/StreamUniTaskTests.cs
@@ -1,0 +1,142 @@
+#if LIVEKIT_UNITASK
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using LiveKit.Internal;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace LiveKit.PlayModeTests.UniTaskBridge
+{
+    public class StreamUniTaskTests
+    {
+        // Synthetic incremental reader that drives the base chunk/EoS machinery directly,
+        // with no FFI — the same seam used by the EditMode DataStreamIncrementalReadTests.
+        // FfiHandle is public; new FfiHandle(IntPtr.Zero) is a valid dummy handle.
+        private sealed class TestIncrementalReader : ReadIncrementalInstructionBase<string>
+        {
+            public TestIncrementalReader(FfiHandle h) : base(h) { }
+            public void PushChunk(string content) => OnChunk(content);
+            public void PushEos(LiveKit.Proto.StreamError error = null) => OnEos(error);
+        }
+
+        // Chunks pushed and consumed one at a time arrive in order; the sequence ends when
+        // EoS is observed. Manual enumeration interleaves push/pull so EoS only follows a
+        // fully drained queue (matching how chunks arrive over time in production).
+        [UnityTest]
+        public System.Collections.IEnumerator AsAsyncEnumerable_DeliversChunksInOrder_ThenStops() => UniTask.ToCoroutine(async () =>
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+
+            var e = reader.AsAsyncEnumerable().GetAsyncEnumerator();
+            try
+            {
+                reader.PushChunk("A");
+                Assert.IsTrue(await e.MoveNextAsync(), "Expected chunk A");
+                Assert.AreEqual("A", e.Current);
+
+                reader.PushChunk("B");
+                Assert.IsTrue(await e.MoveNextAsync(), "Expected chunk B");
+                Assert.AreEqual("B", e.Current);
+
+                reader.PushChunk("C");
+                Assert.IsTrue(await e.MoveNextAsync(), "Expected chunk C");
+                Assert.AreEqual("C", e.Current);
+
+                reader.PushEos();
+                Assert.IsFalse(await e.MoveNextAsync(), "Enumeration must end at EoS");
+            }
+            finally
+            {
+                await e.DisposeAsync();
+            }
+        });
+
+        // The current chunk is delivered even when EoS is already set at the time it is read,
+        // then the sequence ends. (Chunks buffered beyond the current one when EoS arrives are
+        // not drainable — a pre-existing reader limitation, asserted here for clarity.)
+        [UnityTest]
+        public System.Collections.IEnumerator AsAsyncEnumerable_DeliversFinalChunkThenEos() => UniTask.ToCoroutine(async () =>
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+
+            reader.PushChunk("only");
+            reader.PushEos();
+
+            var observed = new List<string>();
+            await foreach (var chunk in reader.AsAsyncEnumerable())
+                observed.Add(chunk);
+
+            CollectionAssert.AreEqual(new[] { "only" }, observed);
+        });
+
+        // A chunk delivered before the stream errors is observed; the subsequent error EoS
+        // then surfaces as a thrown StreamError. Manual enumeration models the real timeline
+        // (chunk arrives, is consumed, THEN the error ends the stream) — note that once the
+        // error is set, LatestChunk itself throws, so the error must follow chunk delivery.
+        [UnityTest]
+        public System.Collections.IEnumerator AsAsyncEnumerable_ThrowsStreamError_AfterDeliveringChunk() => UniTask.ToCoroutine(async () =>
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+
+            var e = reader.AsAsyncEnumerable().GetAsyncEnumerator();
+            try
+            {
+                reader.PushChunk("partial");
+                Assert.IsTrue(await e.MoveNextAsync(), "Expected the pre-error chunk");
+                Assert.AreEqual("partial", e.Current);
+
+                reader.PushEos(new LiveKit.Proto.StreamError { Description = "boom" });
+
+                StreamError caught = null;
+                try
+                {
+                    await e.MoveNextAsync();
+                }
+                catch (StreamError ex)
+                {
+                    caught = ex;
+                }
+
+                Assert.IsNotNull(caught, "Expected the error EoS to throw a StreamError");
+                Assert.AreEqual("boom", caught.Message);
+            }
+            finally
+            {
+                await e.DisposeAsync();
+            }
+        });
+
+        // A cancelled token surfaces as OperationCanceledException with abandon-awaiter
+        // semantics: nothing is observed and the underlying reader is untouched.
+        [UnityTest]
+        public System.Collections.IEnumerator AsAsyncEnumerable_Cancellation_ThrowsOperationCanceled() => UniTask.ToCoroutine(async () =>
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var observed = new List<string>();
+            bool threw = false;
+            try
+            {
+                await foreach (var chunk in reader.AsAsyncEnumerable(cts.Token))
+                    observed.Add(chunk);
+            }
+            catch (OperationCanceledException)
+            {
+                threw = true;
+            }
+
+            Assert.IsTrue(threw, "Expected OperationCanceledException for a cancelled token");
+            CollectionAssert.IsEmpty(observed);
+            Assert.IsFalse(reader.IsEos, "Abandon-awaiter semantics: reader state is untouched");
+        });
+    }
+}
+#endif

--- a/Tests/PlayMode/UniTask/StreamUniTaskTests.cs.meta
+++ b/Tests/PlayMode/UniTask/StreamUniTaskTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2e6312b068f8432fa2b267f28d3e10b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Adds a single generic extension `AsAsyncEnumerable<TChunk>(this ReadIncrementalInstructionBase<TChunk>, CancellationToken)` in the gated `LiveKit.UniTask` assembly, so `ByteStreamReader`/`TextStreamReader` incremental reads can be consumed with `await foreach` (returns `IUniTaskAsyncEnumerable<byte[]>` / `<string>`).
- Builds on Stage 1's `StreamYieldInstruction` awaiter and Stage 2's `AsUniTask`. The loop mirrors the coroutine consumer's observable behavior: await a chunk → yield it → re-check `IsEos` **after** yielding (since `Reset()` is disallowed past EoS) → `Reset()` for the next chunk.

```csharp
var reader = await OpenByteStream(...);
try {
    await foreach (var chunk in reader.ReadIncremental().AsAsyncEnumerable(ct))
        Process(chunk);
} catch (StreamError e) {
    Debug.LogError(e.Message);
}
```

## Design decisions
- **Error model:** on EoS carrying a `StreamError`, the enumerable **throws** it (idiomatic for `await foreach` — the one place the UniTask surface throws rather than exposing `IsError`). Note: once an error is set, `LatestChunk` itself throws, so a chunk and an error never surface from the same step (a chunk delivered *before* the error is observed normally; the error then ends iteration).
- **Cancellation:** `OperationCanceledException`, abandon-awaiter semantics (consistent with Stage 2).
- **Scope:** byte/text incremental readers only. `DataTrack.ReadFrameInstruction` is out of scope (no awaiter, no `Reset()`) — possible follow-up.
- **No sample migration:** the Meet sample reads no incremental streams; Stage 3 is adapter + deterministic tests.

## Supporting changes (core `LiveKit` asm, behavior-preserving)
- Widen `StreamYieldInstruction.IsCurrentReadDone` getter and `ReadIncrementalInstructionBase<T>.LatestChunk` to `public` so the separate `LiveKit.UniTask` assembly can drive the loop. Both already have public equivalents on the sibling `DataTrack.ReadFrameInstruction`.
- Add `UniTask.Linq` reference to the runtime + test UniTask asmdefs (source of `UniTaskAsyncEnumerable.Create` / `IUniTaskAsyncEnumerable`).
- Extend `InternalsVisibleTo` to `PlayModeTests.UniTask` so the deterministic tests can construct a synthetic reader via the public `FfiHandle` seam the EditMode tests already use.

## Testing
`Tests/PlayMode/UniTask/StreamUniTaskTests.cs` (gated by `LIVEKIT_UNITASK`), using a synthetic `TestIncrementalReader : ReadIncrementalInstructionBase<string>` with `PushChunk`/`PushEos` — the same FFI-free seam as `DataStreamIncrementalReadTests`:
- delivers chunks in order then stops at EoS (manual enumeration, interleaved push/pull)
- delivers the final chunk when EoS is already set, then stops
- delivers a chunk then throws `StreamError` on a subsequent error EoS
- already-cancelled token throws `OperationCanceledException`, observes nothing

## Test plan
- [x] `Scripts~/run_unity.sh build macos` — clean compile.
- [x] `Scripts~/run_unity.sh test -m PlayMode -f "AsAsyncEnumerable|AsUniTask|GetAwaiter"` — 8 passed, 0 failed (4 new stream tests + inherited Stage 1/2).
- [x] `Scripts~/run_unity.sh test -m EditMode` — 70 passed, 2 skipped (confirms the visibility widening didn't regress `DataStreamIncrementalReadTests`).

## Targeting
Base branch is `max/yield-instruction-unitask-extension` (Stage 2, PR #290), so this diff shows only the Stage 3 surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)