### PR TITLE
Use Utils logging helpers instead of raw Debug.Log in SDK runtime

### DIFF
--- a/Runtime/Scripts/Rpc.cs
+++ b/Runtime/Scripts/Rpc.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using UnityEngine;
+using LiveKit.Internal;
 
 namespace LiveKit
 {
@@ -90,7 +90,7 @@ namespace LiveKit
 
         internal static RpcError FromProto(Proto.RpcError proto)
         {
-            Debug.Log($"RPC error received: {proto.Code} {proto.Message} {proto.Data}");
+            Utils.Debug($"RPC error received: {proto.Code} {proto.Message} {proto.Data}");
             return new RpcError(proto.Code, proto.Message, proto.Data);
         }
 

--- a/Runtime/Scripts/RtcAudioSource.cs
+++ b/Runtime/Scripts/RtcAudioSource.cs
@@ -96,7 +96,7 @@ namespace LiveKit
                 DefaultMicrophoneSampleRate : DefaultSampleRate;
             _expectedSampleRate = newAudioSource.SampleRate;
 
-            UnityEngine.Debug.Log($"NewAudioSource: {newAudioSource.NumChannels} {newAudioSource.SampleRate}");
+            Utils.Debug($"NewAudioSource: {newAudioSource.NumChannels} {newAudioSource.SampleRate}");
 
             newAudioSource.Options = request.TempResource<AudioSourceOptions>();
             newAudioSource.Options.EchoCancellation = true;

--- a/Runtime/Scripts/RtcVideoSource.cs
+++ b/Runtime/Scripts/RtcVideoSource.cs
@@ -216,7 +216,7 @@ namespace LiveKit
                  UnityEngine.Object.Destroy(_previewTexture);
             if (_captureBuffer.IsCreated)
             {
-                Debug.Log("Disposing capture buffer");
+                Utils.Debug("Disposing capture buffer");
                 _captureBuffer.Dispose();
             }
             Handle?.Dispose();

--- a/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using UnityEngine;
+using LiveKit.Internal;
 
 namespace LiveKit
 {
@@ -67,7 +68,7 @@ namespace LiveKit
 
                 case ITokenSourceFixed fixedSource:
                     if (options != null)
-                        Debug.LogWarning("TokenSourceComponent uses a fixed config, so fetch options are ignored.");
+                        Utils.Warning("TokenSourceComponent uses a fixed config, so fetch options are ignored.");
                     task = fixedSource.FetchConnectionDetails();
                     break;
 


### PR DESCRIPTION
## What

Replaces the four remaining raw `UnityEngine.Debug.Log*` calls in the SDK runtime (`Runtime/Scripts/`, excluding generated `Proto/`) with the SDK's `Utils` logging helpers, so all runtime logging follows the established convention: `LK_DEBUG`-gated for debug, and `"LiveKit"`-prefixed.

| File | Before | After | Rationale |
|---|---|---|---|
| `RtcAudioSource.cs` | `UnityEngine.Debug.Log` | `Utils.Debug` | Informational; matches the `Utils.Debug` neighbor and drops the explicit qualifier previously needed to disambiguate from `System.Diagnostics.Debug` |
| `RtcVideoSource.cs` | `Debug.Log` | `Utils.Debug` | Dispose-path diagnostic |
| `Rpc.cs` | `Debug.Log` | `Utils.Debug` | RPC errors are often normal app-level results — shouldn't spam release logs |
| `TokenSourceComponent.cs` | `Debug.LogWarning` | `Utils.Warning` | Genuine developer misconfiguration warning; should stay visible in all builds |

Supporting changes:
- Added `using LiveKit.Internal;` to `Rpc.cs` and `TokenSourceComponent.cs` (where `Utils` lives).
- Removed the now-unused `using UnityEngine;` from `Rpc.cs`.

## Effect

The three `Utils.Debug` conversions now compile out unless `LK_DEBUG` is defined (quieter release builds); the `Utils.Warning` keeps the token-source warning visible and gains the `"LiveKit"` prefix.

## Verification

Compiled the SDK runtime assembly via `dotnet build` on `LiveKit.csproj` — **build succeeded, 0 errors** (22 pre-existing, unrelated warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)