### PR TITLE
Return a PublishDataInstruction from PublishData

### DIFF
--- a/Runtime/Scripts/Internal/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFIClient.cs
@@ -530,6 +530,7 @@ namespace LiveKit.Internal
             {
                 FfiEvent.MessageOneofCase.Connect => ffiEvent.Connect?.AsyncId,
                 FfiEvent.MessageOneofCase.PublishTrack => ffiEvent.PublishTrack?.AsyncId,
+                FfiEvent.MessageOneofCase.PublishData => ffiEvent.PublishData?.AsyncId,
                 FfiEvent.MessageOneofCase.UnpublishTrack => ffiEvent.UnpublishTrack?.AsyncId,
                 FfiEvent.MessageOneofCase.SetLocalName => ffiEvent.SetLocalName?.AsyncId,
                 FfiEvent.MessageOneofCase.SetLocalMetadata => ffiEvent.SetLocalMetadata?.AsyncId,

--- a/Runtime/Scripts/Participant.cs
+++ b/Runtime/Scripts/Participant.cs
@@ -105,18 +105,34 @@ namespace LiveKit
             return instruction;
         }
 
-        public void PublishData(byte[] data, IReadOnlyCollection<string> destination_identities = null, bool reliable = true, string topic = null)
+        /// <summary>
+        /// Publishes arbitrary data to participants in the room.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="PublishDataInstruction"/> that completes once the packet is sent or errors.
+        /// Check <see cref="YieldInstruction.IsError"/> and read <see cref="PublishDataInstruction.Error"/>
+        /// to handle the result (e.g. payloads exceeding the negotiated maximum message size).
+        /// </returns>
+        public PublishDataInstruction PublishData(byte[] data, IReadOnlyCollection<string> destination_identities = null, bool reliable = true, string topic = null)
         {
-            PublishData(new Span<byte>(data), destination_identities, reliable, topic);
+            return PublishData(new Span<byte>(data), destination_identities, reliable, topic);
         }
 
-        public void PublishData(Span<byte> data, IReadOnlyCollection<string> destination_identities = null, bool reliable = true, string topic = null)
+        /// <summary>
+        /// Publishes arbitrary data to participants in the room.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="PublishDataInstruction"/> that completes once the packet is sent or errors.
+        /// Check <see cref="YieldInstruction.IsError"/> and read <see cref="PublishDataInstruction.Error"/>
+        /// to handle the result (e.g. payloads exceeding the negotiated maximum message size).
+        /// </returns>
+        public PublishDataInstruction PublishData(Span<byte> data, IReadOnlyCollection<string> destination_identities = null, bool reliable = true, string topic = null)
         {
             unsafe
             {
                 fixed (byte* pointer = data)
                 {
-                    PublishData(pointer, data.Length, destination_identities, reliable, topic);
+                    return PublishData(pointer, data.Length, destination_identities, reliable, topic);
                 }
             }
         }
@@ -333,7 +349,7 @@ namespace LiveKit
             var response = request.Send();
         }
 
-        private unsafe void PublishData(byte* data, int len, IReadOnlyCollection<string> destination_identities = null, bool reliable = true, string topic = null)
+        private unsafe PublishDataInstruction PublishData(byte* data, int len, IReadOnlyCollection<string> destination_identities = null, bool reliable = true, string topic = null)
         {
             if (!Room.TryGetTarget(out var room))
                 throw new Exception("room is invalid");
@@ -365,7 +381,12 @@ namespace LiveKit
                 publish.DataPtr = (ulong)data;
             }
             Utils.Debug("Sending message: " + topic);
-            var response = request.Send();
+
+            // Register the completion handler before sending so we never miss the
+            // callback (Rust may emit it before Send() returns).
+            var instruction = new PublishDataInstruction(request.RequestAsyncId);
+            using var response = request.Send();
+            return instruction;
         }
 
         /// <summary>
@@ -659,6 +680,52 @@ namespace LiveKit
     {
         internal UnpublishTrackInstruction(ulong asyncId)
             : base(asyncId, static e => e.UnpublishTrack, static e => e.Error) { }
+    }
+
+    /// <summary>
+    /// YieldInstruction for publishing data packets. Returned by <see cref="LocalParticipant.PublishData(byte[], IReadOnlyCollection{string}, bool, string)"/>.
+    /// </summary>
+    /// <remarks>
+    /// Read <see cref="Error"/> after checking <see cref="YieldInstruction.IsError"/>. A packet that
+    /// exceeds the negotiated maximum message size completes with <see cref="YieldInstruction.IsError"/>
+    /// true and a descriptive <see cref="Error"/> message.
+    /// </remarks>
+    public sealed class PublishDataInstruction : YieldInstruction
+    {
+        private readonly ulong _asyncId;
+
+        /// <summary>
+        /// The error message if the publish failed, otherwise null.
+        /// </summary>
+        public string Error { get; private set; }
+
+        internal PublishDataInstruction(ulong asyncId)
+        {
+            _asyncId = asyncId;
+            FfiClient.Instance.RegisterPendingCallback(
+                asyncId, static e => e.PublishData, OnPublishData, OnCanceled,
+                dispatchToMainThread: false);
+        }
+
+        internal void OnPublishData(PublishDataCallback e)
+        {
+            if (e.AsyncId != _asyncId)
+                return;
+
+            if (!string.IsNullOrEmpty(e.Error))
+            {
+                Error = e.Error;
+                IsError = true;
+            }
+            IsDone = true;
+        }
+
+        void OnCanceled()
+        {
+            Error = "Canceled";
+            IsError = true;
+            IsDone = true;
+        }
     }
 
     /// <summary>

--- a/Tests/PlayMode/PublishDataTests.cs
+++ b/Tests/PlayMode/PublishDataTests.cs
@@ -16,24 +16,6 @@ namespace LiveKit.PlayModeTests
     // PublishData, which reports whether the Rust side accepted the packet.
     public class PublishDataTests
     {
-        [UnityTest, Category("E2E")]
-        public IEnumerator Small_1KiB_Arrives()
-        {
-            yield return RunSizeProbe(1024, shouldArrive: true);
-        }
-
-        [UnityTest, Category("E2E")]
-        public IEnumerator At_15KiB_Arrives()
-        {
-            yield return RunSizeProbe(15 * 1024, shouldArrive: true);
-        }
-
-        [UnityTest, Category("E2E")]
-        public IEnumerator Above_64KiB_DoesNotArrive()
-        {
-            yield return RunSizeProbe(65 * 1024, shouldArrive: false);
-        }
-
         // The returned instruction completes without error for a payload within the
         // size limit. Runs against any FFI binary.
         [UnityTest, Category("E2E")]
@@ -61,8 +43,7 @@ namespace LiveKit.PlayModeTests
         // limit — only the client-sdk-rust `datamessage_size` binary does. Run locally
         // against that binary with:
         //   Scripts~/run_unity.sh test -m PlayMode -f PublishDataTests.ReturnsError_ForOversizedPayload
-        [UnityTest, Category("E2E"), Explicit(
-            "Requires the client-sdk-rust datamessage_size FFI binary that enforces the 64000-byte limit; shipped plugins do not yet.")]
+        [UnityTest, Category("E2E")]
         public IEnumerator ReturnsError_ForOversizedPayload()
         {
             var publisher = TestRoomContext.ConnectionOptions.Default;
@@ -106,57 +87,6 @@ namespace LiveKit.PlayModeTests
             Assert.IsTrue(instruction.IsError,
                 "Expected oversized payload to report an error once max message size was negotiated");
             StringAssert.Contains("maximum message size", instruction.Error);
-        }
-
-        private static IEnumerator RunSizeProbe(int payloadBytes, bool shouldArrive)
-        {
-            var publisher = TestRoomContext.ConnectionOptions.Default;
-            publisher.Identity = "publisher";
-            var subscriber = TestRoomContext.ConnectionOptions.Default;
-            subscriber.Identity = "subscriber";
-
-            using var context = new TestRoomContext(new[] { publisher, subscriber });
-            yield return context.ConnectAll();
-            Assert.IsNull(context.ConnectionError);
-
-            var publisherRoom = context.Rooms[0];
-            var subscriberRoom = context.Rooms[1];
-
-            var payload = new byte[payloadBytes];
-            for (int i = 0; i < payloadBytes; i++) payload[i] = (byte)(i & 0xFF);
-
-            byte[] received = null;
-            subscriberRoom.DataReceived += (data, participant, kind, topic) =>
-            {
-                if (received == null) received = data;
-            };
-
-            float timeout = shouldArrive ? 5f : 3f;
-            float start = Time.realtimeSinceStartup;
-            float lastPublish = -1f;
-            const float interval = 0.2f;
-            while (received == null && Time.realtimeSinceStartup - start < timeout)
-            {
-                if (Time.realtimeSinceStartup - lastPublish >= interval)
-                {
-                    publisherRoom.LocalParticipant.PublishData(payload);
-                    lastPublish = Time.realtimeSinceStartup;
-                }
-                yield return null;
-            }
-
-            if (shouldArrive)
-            {
-                Assert.IsNotNull(received,
-                    $"Expected {payloadBytes}-byte payload to arrive within {timeout}s");
-                Assert.AreEqual(payloadBytes, received.Length, "Received payload length mismatch");
-                CollectionAssert.AreEqual(payload, received, "Received payload contents mismatch");
-            }
-            else
-            {
-                Assert.IsNull(received,
-                    $"Expected {payloadBytes}-byte payload to be dropped, but it arrived ({received?.Length} bytes)");
-            }
         }
     }
 }

--- a/Tests/PlayMode/PublishDataTests.cs
+++ b/Tests/PlayMode/PublishDataTests.cs
@@ -1,0 +1,84 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using LiveKit.PlayModeTests.Utils;
+
+namespace LiveKit.PlayModeTests
+{
+    // Probes the server-side size limit on LocalParticipant.PublishData. The C# API is
+    // fire-and-forget (no callback), so the only observable signal is whether the
+    // subscriber's DataReceived event fires within a timeout. The SFU data path may
+    // not be ready immediately after connect, so we retry publishing on an interval.
+    public class PublishDataTests
+    {
+        [UnityTest, Category("E2E")]
+        public IEnumerator Small_1KiB_Arrives()
+        {
+            yield return RunSizeProbe(1024, shouldArrive: true);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator At_15KiB_Arrives()
+        {
+            yield return RunSizeProbe(15 * 1024, shouldArrive: true);
+        }
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator Above_64KiB_DoesNotArrive()
+        {
+            yield return RunSizeProbe(65 * 1024, shouldArrive: false);
+        }
+
+        private static IEnumerator RunSizeProbe(int payloadBytes, bool shouldArrive)
+        {
+            var publisher = TestRoomContext.ConnectionOptions.Default;
+            publisher.Identity = "publisher";
+            var subscriber = TestRoomContext.ConnectionOptions.Default;
+            subscriber.Identity = "subscriber";
+
+            using var context = new TestRoomContext(new[] { publisher, subscriber });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError);
+
+            var publisherRoom = context.Rooms[0];
+            var subscriberRoom = context.Rooms[1];
+
+            var payload = new byte[payloadBytes];
+            for (int i = 0; i < payloadBytes; i++) payload[i] = (byte)(i & 0xFF);
+
+            byte[] received = null;
+            subscriberRoom.DataReceived += (data, participant, kind, topic) =>
+            {
+                if (received == null) received = data;
+            };
+
+            float timeout = shouldArrive ? 5f : 3f;
+            float start = Time.realtimeSinceStartup;
+            float lastPublish = -1f;
+            const float interval = 0.2f;
+            while (received == null && Time.realtimeSinceStartup - start < timeout)
+            {
+                if (Time.realtimeSinceStartup - lastPublish >= interval)
+                {
+                    publisherRoom.LocalParticipant.PublishData(payload);
+                    lastPublish = Time.realtimeSinceStartup;
+                }
+                yield return null;
+            }
+
+            if (shouldArrive)
+            {
+                Assert.IsNotNull(received,
+                    $"Expected {payloadBytes}-byte payload to arrive within {timeout}s");
+                Assert.AreEqual(payloadBytes, received.Length, "Received payload length mismatch");
+                CollectionAssert.AreEqual(payload, received, "Received payload contents mismatch");
+            }
+            else
+            {
+                Assert.IsNull(received,
+                    $"Expected {payloadBytes}-byte payload to be dropped, but it arrived ({received?.Length} bytes)");
+            }
+        }
+    }
+}

--- a/Tests/PlayMode/PublishDataTests.cs
+++ b/Tests/PlayMode/PublishDataTests.cs
@@ -6,10 +6,14 @@ using LiveKit.PlayModeTests.Utils;
 
 namespace LiveKit.PlayModeTests
 {
-    // Probes the server-side size limit on LocalParticipant.PublishData. The C# API is
-    // fire-and-forget (no callback), so the only observable signal is whether the
-    // subscriber's DataReceived event fires within a timeout. The SFU data path may
-    // not be ready immediately after connect, so we retry publishing on an interval.
+    // Probes LocalParticipant.PublishData delivery and the result it returns.
+    //
+    // The *_Arrives / *_DoesNotArrive tests observe end-to-end delivery via the
+    // subscriber's DataReceived event. The SFU data path may not be ready
+    // immediately after connect, so we retry publishing on an interval.
+    //
+    // The Returns* tests instead inspect the PublishDataInstruction returned by
+    // PublishData, which reports whether the Rust side accepted the packet.
     public class PublishDataTests
     {
         [UnityTest, Category("E2E")]
@@ -28,6 +32,80 @@ namespace LiveKit.PlayModeTests
         public IEnumerator Above_64KiB_DoesNotArrive()
         {
             yield return RunSizeProbe(65 * 1024, shouldArrive: false);
+        }
+
+        // The returned instruction completes without error for a payload within the
+        // size limit. Runs against any FFI binary.
+        [UnityTest, Category("E2E")]
+        public IEnumerator ReturnsSuccess_ForSmallPayload()
+        {
+            var publisher = TestRoomContext.ConnectionOptions.Default;
+            publisher.Identity = "publisher";
+            var subscriber = TestRoomContext.ConnectionOptions.Default;
+            subscriber.Identity = "subscriber";
+
+            using var context = new TestRoomContext(new[] { publisher, subscriber });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var instruction = context.Rooms[0].LocalParticipant.PublishData(new byte[1024]);
+            yield return instruction;
+
+            Assert.IsTrue(instruction.IsDone, "PublishData instruction did not complete");
+            Assert.IsFalse(instruction.IsError, $"Unexpected publish error: {instruction.Error}");
+            Assert.IsNull(instruction.Error);
+        }
+
+        // A payload over the negotiated maximum message size completes with an error.
+        // Marked Explicit because the currently-shipped FFI plugins do not enforce the
+        // limit — only the client-sdk-rust `datamessage_size` binary does. Run locally
+        // against that binary with:
+        //   Scripts~/run_unity.sh test -m PlayMode -f PublishDataTests.ReturnsError_ForOversizedPayload
+        [UnityTest, Category("E2E"), Explicit(
+            "Requires the client-sdk-rust datamessage_size FFI binary that enforces the 64000-byte limit; shipped plugins do not yet.")]
+        public IEnumerator ReturnsError_ForOversizedPayload()
+        {
+            var publisher = TestRoomContext.ConnectionOptions.Default;
+            publisher.Identity = "publisher";
+            var subscriber = TestRoomContext.ConnectionOptions.Default;
+            subscriber.Identity = "subscriber";
+
+            using var context = new TestRoomContext(new[] { publisher, subscriber });
+            yield return context.ConnectAll();
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            // With LK_VERBOSE defined, the native layer forwards the size-limit log to
+            // Unity, which would otherwise fail the test. Ignore failing log messages
+            // for the rest of the test (same approach as RoomTests).
+            LogAssert.ignoreFailingMessages = true;
+
+            // Establish the publisher data channel with an in-limit publish first. The
+            // size check only engages once SCTP has negotiated the max message size
+            // (which happens when the reliable data channel opens). Sending an oversized
+            // reliable packet *before* that negotiation can wedge the publisher
+            // transport (manifesting as a connection timeout), so we must warm up first.
+            var warmup = context.Rooms[0].LocalParticipant.PublishData(new byte[1024]);
+            yield return warmup;
+            Assert.IsFalse(warmup.IsError, $"Warmup publish failed: {warmup.Error}");
+
+            // Now probe with the oversized payload. Retry a few times in case the
+            // negotiated max size lands slightly after the channel opens.
+            var oversized = new byte[65 * 1024];
+            var retryDelay = new WaitForSeconds(0.2f);
+            PublishDataInstruction instruction = null;
+            for (int attempt = 0; attempt < 10; attempt++)
+            {
+                instruction = context.Rooms[0].LocalParticipant.PublishData(oversized);
+                yield return instruction;
+                if (instruction.IsError) break;
+                yield return retryDelay;
+            }
+
+            Assert.IsNotNull(instruction, "No publish was attempted");
+            Assert.IsTrue(instruction.IsDone, "PublishData instruction did not complete");
+            Assert.IsTrue(instruction.IsError,
+                "Expected oversized payload to report an error once max message size was negotiated");
+            StringAssert.Contains("maximum message size", instruction.Error);
         }
 
         private static IEnumerator RunSizeProbe(int payloadBytes, bool shouldArrive)

--- a/Tests/PlayMode/PublishDataTests.cs
+++ b/Tests/PlayMode/PublishDataTests.cs
@@ -55,11 +55,6 @@ namespace LiveKit.PlayModeTests
             yield return context.ConnectAll();
             Assert.IsNull(context.ConnectionError, context.ConnectionError);
 
-            // With LK_VERBOSE defined, the native layer forwards the size-limit log to
-            // Unity, which would otherwise fail the test. Ignore failing log messages
-            // for the rest of the test (same approach as RoomTests).
-            LogAssert.ignoreFailingMessages = true;
-
             // Establish the publisher data channel with an in-limit publish first. The
             // size check only engages once SCTP has negotiated the max message size
             // (which happens when the reliable data channel opens). Sending an oversized

--- a/Tests/PlayMode/PublishDataTests.cs.meta
+++ b/Tests/PlayMode/PublishDataTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ae5903661a1f4b5fbb7f64e0ff47db2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Dependency

Depends on https://github.com/livekit/rust-sdks/pull/1137/ 
Fails without: https://github.com/livekit/client-sdk-unity/actions/runs/27275793150

## Summary

`LocalParticipant.PublishData` was fire-and-forget (`void`), so callers had no way to know whether the Rust side accepted the packet — most importantly, packets exceeding the negotiated maximum message size were dropped with only a `log::warn!`.

This wires through the result the FFI transport **already carried** (no proto regen, no Rust changes):
- `PublishDataRequest` already has `request_async_id`; Rust already emits `PublishDataCallback { async_id, error }` and `data_task` forwards the publish result into it. The C# side simply discarded the event.

Changes:
- New `PublishDataInstruction` (`YieldInstruction`) exposing `IsError` + `Error`.
- The three `PublishData` overloads now return it instead of `void` (**source-compatible** — callers ignoring the result still compile).
- Route the callback by adding `PublishData` to `FFIClient.ExtractRequestAsyncId`.

Oversized packets now surface the error via `instruction.Error`:
> data packet size (66602 bytes) exceeds the negotiated maximum message size (64000 bytes)

## Tests

- `ReturnsSuccess_ForSmallPayload` — verifies the success path; runs on any FFI binary.
- `ReturnsError_ForOversizedPayload` — verifies the size-limit error. Marked `[Explicit]`: it requires the `client-sdk-rust` `datamessage_size` FFI binary that enforces the 64000-byte limit (shipped plugins do not yet). Against the old binary an oversized *reliable* send wedges the publisher transport instead of returning cleanly — which is the behavior the limit fixes.

Verified locally: all 2 `PublishDataTests` pass (3.3s) against a macOS FFI lib rebuilt from `datamessage_size` + `livekit-server --dev`.