### PR TITLE
Configure native audio source from device config instead of hardcoded defaults

### DIFF
--- a/Runtime/Scripts/BasicAudioSource.cs
+++ b/Runtime/Scripts/BasicAudioSource.cs
@@ -19,9 +19,11 @@ namespace LiveKit
         /// Creates a new basic audio source for the given <see cref="AudioSource"/> in the scene.
         /// </summary>
         /// <param name="source">The <see cref="AudioSource"/> to capture from.</param>
-        /// <param name="channels">The number of channels to capture.</param>
         /// <param name="sourceType">The type of audio source.</param>
-        public BasicAudioSource(AudioSource source, int channels = 2, RtcAudioSourceType sourceType = RtcAudioSourceType.AudioSourceCustom) : base(channels, sourceType)
+        /// <remarks>
+        /// The sample rate and channel count are taken from Unity's audio configuration.
+        /// </remarks>
+        public BasicAudioSource(AudioSource source, RtcAudioSourceType sourceType = RtcAudioSourceType.AudioSourceCustom) : base(sourceType)
         {
             _source = source;
         }

--- a/Runtime/Scripts/MicrophoneSource.cs
+++ b/Runtime/Scripts/MicrophoneSource.cs
@@ -28,7 +28,7 @@ namespace LiveKit
         /// get the list of available devices.</param>
         /// <param name="sourceObject">The GameObject to attach the AudioSource to. The object must be kept in the scene
         /// for the duration of the source's lifetime.</param>
-        public MicrophoneSource(string deviceName, GameObject sourceObject) : base(2, RtcAudioSourceType.AudioSourceMicrophone)
+        public MicrophoneSource(string deviceName, GameObject sourceObject) : base(RtcAudioSourceType.AudioSourceMicrophone)
         {
             _deviceName = deviceName;
             _sourceObject = sourceObject;

--- a/Runtime/Scripts/MicrophoneSource.cs
+++ b/Runtime/Scripts/MicrophoneSource.cs
@@ -82,7 +82,7 @@ namespace LiveKit
                     _deviceName,
                     loop: true,
                     lengthSec: 1,
-                    frequency: (int)DefaultMicrophoneSampleRate
+                    frequency: (int)_expectedSampleRate
                 );
             }
             catch (Exception e)

--- a/Runtime/Scripts/RtcAudioSource.cs
+++ b/Runtime/Scripts/RtcAudioSource.cs
@@ -83,20 +83,33 @@ namespace LiveKit
         private volatile bool _disposed = false;
         private int _audioReadCount = 0;
 
-        protected RtcAudioSource(int channels = 2, RtcAudioSourceType audioSourceType = RtcAudioSourceType.AudioSourceCustom)
+        // Device-capture sources (microphone, AudioSource taps) don't know their format ahead of
+        // time — it is whatever Unity's audio graph delivers. They use this constructor, which
+        // configures the native source from Unity's current output configuration.
+        protected RtcAudioSource(RtcAudioSourceType audioSourceType)
+            : this(audioSourceType, 0, 0) { }
+
+        // Sources that generate a fixed, known format (e.g. test signal generators) declare it
+        // directly. Passing 0 for either value falls back to the device configuration.
+        protected RtcAudioSource(RtcAudioSourceType audioSourceType, uint sampleRate, uint channels)
         {
             _sourceType = audioSourceType;
-            _expectedChannels = (uint)channels;
+
+            if (sampleRate > 0 && channels > 0)
+            {
+                _expectedSampleRate = sampleRate;
+                _expectedChannels = channels;
+            }
+            else
+            {
+                (_expectedSampleRate, _expectedChannels) = ResolveDeviceFormat();
+            }
 
             using var request = FFIBridge.Instance.NewRequest<NewAudioSourceRequest>();
             var newAudioSource = request.request;
             newAudioSource.Type = AudioSourceType.AudioSourceNative;
-            newAudioSource.NumChannels = (uint)channels;
-            newAudioSource.SampleRate = _sourceType == RtcAudioSourceType.AudioSourceMicrophone ?
-                DefaultMicrophoneSampleRate : DefaultSampleRate;
-            _expectedSampleRate = newAudioSource.SampleRate;
-
-            Utils.Debug($"NewAudioSource: {newAudioSource.NumChannels} {newAudioSource.SampleRate}");
+            newAudioSource.NumChannels = _expectedChannels;
+            newAudioSource.SampleRate = _expectedSampleRate;
 
             newAudioSource.Options = request.TempResource<AudioSourceOptions>();
             newAudioSource.Options.EchoCancellation = true;
@@ -107,6 +120,49 @@ namespace LiveKit
             _info = res.NewAudioSource.Source.Info;
             Handle = FfiHandle.FromOwnedHandle(res.NewAudioSource.Source.Handle);
             Utils.Debug($"{DebugTag} created handle={Handle.DangerousGetHandle()} expectedRate={_expectedSampleRate} expectedChannels={_expectedChannels} sourceType={_sourceType}");
+        }
+
+        // Reads Unity's actual output audio configuration. The capture path delivers buffers at the
+        // DSP output rate/channel count (see AudioProbe), so this is the format the native source
+        // must match. Falls back to the platform defaults when Unity cannot report a configuration
+        // (e.g. batch mode without an audio device).
+        private (uint sampleRate, uint channels) ResolveDeviceFormat()
+        {
+            uint sampleRate = _sourceType == RtcAudioSourceType.AudioSourceMicrophone
+                ? DefaultMicrophoneSampleRate
+                : DefaultSampleRate;
+            uint channels = DefaultChannels;
+
+            try
+            {
+                var config = UnityEngine.AudioSettings.GetConfiguration();
+                if (config.sampleRate > 0)
+                    sampleRate = (uint)config.sampleRate;
+                var configuredChannels = SpeakerModeChannels(config.speakerMode);
+                if (configuredChannels > 0)
+                    channels = configuredChannels;
+            }
+            catch (Exception e)
+            {
+                Utils.Warning($"{DebugTag} could not read Unity audio configuration, using defaults: {e.Message}");
+            }
+
+            return (sampleRate, channels);
+        }
+
+        private static uint SpeakerModeChannels(UnityEngine.AudioSpeakerMode mode)
+        {
+            switch (mode)
+            {
+                case UnityEngine.AudioSpeakerMode.Mono: return 1;
+                case UnityEngine.AudioSpeakerMode.Stereo: return 2;
+                case UnityEngine.AudioSpeakerMode.Quad: return 4;
+                case UnityEngine.AudioSpeakerMode.Surround: return 5;
+                case UnityEngine.AudioSpeakerMode.Mode5point1: return 6;
+                case UnityEngine.AudioSpeakerMode.Mode7point1: return 8;
+                case UnityEngine.AudioSpeakerMode.Prologic: return 2;
+                default: return 0;
+            }
         }
 
         /// <summary>

--- a/Runtime/Scripts/RtcAudioSource.cs
+++ b/Runtime/Scripts/RtcAudioSource.cs
@@ -46,22 +46,11 @@ namespace LiveKit
         /// </remarks>
         public abstract event Action<float[], int, int> AudioRead;
 
-#if UNITY_IOS && !UNITY_EDITOR
-        // iOS microphone sample rate is 24k
-        public static uint DefaultMicrophoneSampleRate = 24000;
-
-        public static uint DefaultSampleRate = 48000;
-#else
-        public static uint DefaultSampleRate = 48000;
-        public static uint DefaultMicrophoneSampleRate = DefaultSampleRate;
-#endif
-        public static uint DefaultChannels = 2;
-
         private readonly RtcAudioSourceType _sourceType;
         public RtcAudioSourceType SourceType => _sourceType;
         private readonly int _debugId = Interlocked.Increment(ref nextDebugId);
-        private readonly uint _expectedSampleRate;
-        private readonly uint _expectedChannels;
+        internal readonly uint _expectedSampleRate;
+        internal readonly uint _expectedChannels;
 
         internal readonly FfiHandle Handle;
         protected AudioSourceInfo _info;
@@ -128,26 +117,12 @@ namespace LiveKit
         // (e.g. batch mode without an audio device).
         private (uint sampleRate, uint channels) ResolveDeviceFormat()
         {
-            uint sampleRate = _sourceType == RtcAudioSourceType.AudioSourceMicrophone
-                ? DefaultMicrophoneSampleRate
-                : DefaultSampleRate;
-            uint channels = DefaultChannels;
+            var config = UnityEngine.AudioSettings.GetConfiguration();
+            var sampleRate = (uint)config.sampleRate;
+            var configuredChannels = SpeakerModeChannels(config.speakerMode);
+            var channels = configuredChannels;
 
-            try
-            {
-                var config = UnityEngine.AudioSettings.GetConfiguration();
-                if (config.sampleRate > 0)
-                    sampleRate = (uint)config.sampleRate;
-                var configuredChannels = SpeakerModeChannels(config.speakerMode);
-                if (configuredChannels > 0)
-                    channels = configuredChannels;
-
-                Utils.Info($"Configured native audio source with sampleRate {sampleRate} and channels {channels}");
-            }
-            catch (Exception e)
-            {
-                Utils.Warning($"{DebugTag} could not read Unity audio configuration, using defaults: {e.Message}");
-            }
+            Utils.Info($"Configured native audio source with sampleRate {sampleRate} and channels {channels}");
 
             return (sampleRate, channels);
         }

--- a/Runtime/Scripts/RtcAudioSource.cs
+++ b/Runtime/Scripts/RtcAudioSource.cs
@@ -141,6 +141,8 @@ namespace LiveKit
                 var configuredChannels = SpeakerModeChannels(config.speakerMode);
                 if (configuredChannels > 0)
                     channels = configuredChannels;
+
+                Utils.Info($"Configured native audio source with sampleRate {sampleRate} and channels {channels}");
             }
             catch (Exception e)
             {

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -453,8 +453,7 @@ public class MeetManager : MonoBehaviour
     {
         if (_audioObjects.ContainsKey(LocalAudioTrackName)) yield break;
 
-        Microphone.Start(null, true, 10, 44100);
-
+        // MicrophoneSource starts the device itself, so we only need the device name here.
         var audioObject = new GameObject($"My Microphone: {Microphone.devices[0]}");
         audioObject.transform.SetParent(_audioTrackParent);
 

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -453,7 +453,9 @@ public class MeetManager : MonoBehaviour
     {
         if (_audioObjects.ContainsKey(LocalAudioTrackName)) yield break;
 
-        // MicrophoneSource starts the device itself, so we only need the device name here.
+        // Start the microphone here for early iOS permission request
+        Microphone.Start(null, true, 10, 44100);
+        
         var audioObject = new GameObject($"My Microphone: {Microphone.devices[0]}");
         audioObject.transform.SetParent(_audioTrackParent);
 

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -453,7 +453,7 @@ public class MeetManager : MonoBehaviour
     {
         if (_audioObjects.ContainsKey(LocalAudioTrackName)) yield break;
 
-        // Start the microphone here for early iOS permission request
+        // Start the microphone here for early iOS permission request and android getting access to Microphone.devices
         Microphone.Start(null, true, 10, 44100);
         
         var audioObject = new GameObject($"My Microphone: {Microphone.devices[0]}");

--- a/Tests/PlayMode/Utils/SineWaveAudioSource.cs
+++ b/Tests/PlayMode/Utils/SineWaveAudioSource.cs
@@ -31,7 +31,7 @@ namespace LiveKit.PlayModeTests.Utils
             int sampleRate = 48000,
             double frequencyHz = 440.0,
             float amplitude = 0.1f)
-            : base(channels, RtcAudioSourceType.AudioSourceCustom)
+            : base(RtcAudioSourceType.AudioSourceCustom, (uint)sampleRate, (uint)channels)
         {
             _channels = channels;
             _sampleRate = sampleRate;


### PR DESCRIPTION
## Problem

When the device's audio output configuration differs from the hardcoded defaults — most commonly with a **Bluetooth headset** — microphone capture fails with `sample_rate and num_channels don't match` and the `RtcAudioSource` metadata-mismatch warning.

**Root cause:** `RtcAudioSource` created the native (Rust) audio source with a fixed `sample_rate` (48000) and `num_channels` (2). But captured frames flow through Unity's audio graph (`AudioProbe.OnAudioFilterRead`) at the **actual DSP output configuration**. The Rust native source does not resample — `NativeAudioSource::capture_frame` rejects any frame whose rate/channels differ from how the source was configured.

## Change

- `RtcAudioSource` now reads the sample rate and channel count from Unity's output configuration (`AudioSettings.GetConfiguration`) instead of hardcoded defaults
- The base constructor exposes two overloads: a **device-mode** one (`RtcAudioSourceType` only) for capture sources whose format is whatever Unity delivers, and an **explicit** one (`type, sampleRate, channels`) for sources that generate a fixed, known format, for example `SineWaveAudioSource` in tests


## Verification

Before, using my Sony MDR-1000X Bluetooth headset, I often got 44100 Hz as sample rate from Unity but we configured to 48000 Hz hard coded. This solves the issue for me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)