### PR TITLE
Fix MissingReferenceException when stopping scene with active mic

### DIFF
--- a/Runtime/Scripts/Internal/MonoBehaviourContext.cs
+++ b/Runtime/Scripts/Internal/MonoBehaviourContext.cs
@@ -34,9 +34,38 @@ namespace LiveKit
         /// Runs a coroutine from a non-MonoBehaviour context, invoking the callback when the
         /// coroutine completes.
         /// </summary>
+        /// <remarks>
+        /// If the singleton has already been destroyed (e.g. during play mode exit or
+        /// application shutdown) the coroutine cannot be started on a MonoBehaviour, so it is
+        /// drained synchronously instead. This keeps cleanup side effects working without
+        /// throwing a <see cref="MissingReferenceException"/>.
+        /// </remarks>
         internal static void RunCoroutine(IEnumerator coroutine, Action onComplete = null)
         {
+            // Unity's overloaded == treats a destroyed object as null.
+            if (_instance == null)
+            {
+                DrainCoroutine(coroutine);
+                onComplete?.Invoke();
+                return;
+            }
+
             _instance.StartCoroutine(WrapCoroutine(coroutine, onComplete));
+        }
+
+        /// <summary>
+        /// Synchronously runs a coroutine to completion, ignoring time-based yield instructions
+        /// and recursing into nested enumerators. Used as a fallback when no MonoBehaviour is
+        /// available to host the coroutine.
+        /// </summary>
+        private static void DrainCoroutine(IEnumerator coroutine)
+        {
+            if (coroutine == null) return;
+            while (coroutine.MoveNext())
+            {
+                if (coroutine.Current is IEnumerator nested)
+                    DrainCoroutine(nested);
+            }
         }
 
         private static IEnumerator WrapCoroutine(IEnumerator coroutine, Action onComplete = null)

--- a/Tests/EditMode/MonoBehaviourContextTests.cs
+++ b/Tests/EditMode/MonoBehaviourContextTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace LiveKit.EditModeTests
+{
+    public class MonoBehaviourContextTests
+    {
+        // Regression test for the MissingReferenceException thrown when the scene is stopped:
+        // Unity tears down the DontDestroyOnLoad LiveKitSDK GameObject (backing the
+        // MonoBehaviourContext singleton) before MeetManager.OnDestroy() runs, then
+        // MicrophoneSource.Stop() calls RunCoroutine on the destroyed instance.
+        //
+        // The real play-mode-exit teardown ordering can't be controlled from a test, but the
+        // throwing call (_instance.StartCoroutine) fires synchronously the moment its host is
+        // destroyed. So we reproduce the precondition deterministically: point _instance at a
+        // destroyed object via DestroyImmediate, then call RunCoroutine. Against the old code
+        // this throws MissingReferenceException; against the fix it drains the coroutine
+        // synchronously and invokes onComplete.
+        [Test]
+        public void RunCoroutine_AfterInstanceDestroyed_DrainsSynchronously_DoesNotThrow()
+        {
+            var instanceField = typeof(MonoBehaviourContext)
+                .GetField("_instance", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(instanceField, "Expected private static MonoBehaviourContext._instance field");
+
+            // Save the global singleton so destroying our stand-in can't disturb other tests.
+            var original = instanceField.GetValue(null);
+            try
+            {
+                var go = new GameObject("temp-monobehaviourcontext");
+                var ctx = go.AddComponent<MonoBehaviourContext>();
+                instanceField.SetValue(null, ctx);
+
+                // Synchronous destroy: _instance now reports == null via Unity's overloaded ==.
+                UnityEngine.Object.DestroyImmediate(go);
+
+                bool ran = false;
+                bool completed = false;
+
+                Assert.DoesNotThrow(
+                    () => MonoBehaviourContext.RunCoroutine(Body(() => ran = true), () => completed = true),
+                    "RunCoroutine must not throw when the singleton has already been destroyed");
+
+                Assert.IsTrue(ran, "coroutine body should have been drained synchronously");
+                Assert.IsTrue(completed, "onComplete should fire after the drained coroutine");
+            }
+            finally
+            {
+                instanceField.SetValue(null, original);
+            }
+        }
+
+        private static IEnumerator Body(Action onStep)
+        {
+            onStep();
+            yield return null;
+        }
+    }
+}

--- a/Tests/EditMode/MonoBehaviourContextTests.cs.meta
+++ b/Tests/EditMode/MonoBehaviourContextTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e666f058c2d5643cf820691de34bc582


### PR DESCRIPTION
## Problem

Stopping the scene with an active microphone source consistently throws:

```
MissingReferenceException: The object of type 'LiveKit.MonoBehaviourContext' has been destroyed but you are still trying to access it.
  at LiveKit.MonoBehaviourContext.RunCoroutine (MonoBehaviourContext.cs:39)
  at LiveKit.MicrophoneSource.Stop (MicrophoneSource.cs:148)
  at MeetManager.OnDestroy ...
```

On play-mode exit, Unity tears down the `DontDestroyOnLoad` `LiveKitSDK` GameObject (backing the `MonoBehaviourContext` singleton) **before** `MeetManager.OnDestroy()` runs. `MicrophoneSource.Stop()` then calls `RunCoroutine`, which did `_instance.StartCoroutine(...)` on the destroyed instance and threw.

## Fix

Guard `RunCoroutine`: when `_instance` has been destroyed (Unity's overloaded `==` reports it as `null`), drain the coroutine synchronously via a new `DrainCoroutine` helper and invoke `onComplete`, instead of touching the dead MonoBehaviour. `DrainCoroutine` recurses into nested enumerators and skips time-based yields (meaningless during shutdown). This keeps cleanup side effects working and protects every caller — `MicrophoneSource` is currently the only one, but the fix lives at the shared entry point rather than at the call site.

## Test

Added an EditMode regression test (`Tests/EditMode/MonoBehaviourContextTests.cs`) that deterministically reproduces the failure mode: it points `_instance` at a `DestroyImmediate`-d object and asserts `RunCoroutine` drains without throwing and still runs the body + `onComplete`. The original singleton is saved/restored via reflection so other tests are unaffected.

The exception fires synchronously from `StartCoroutine` once its host is destroyed, so the test reproduces the precondition deterministically without needing Unity's actual play-mode-exit teardown ordering. Against the pre-fix code it fails with `MissingReferenceException`; with the fix it passes.