### PR TITLE
Add deployment field to agent dispatch in TokenSource

### DIFF
--- a/Editor/TokenSourceComponentConfigEditor.cs
+++ b/Editor/TokenSourceComponentConfigEditor.cs
@@ -59,5 +59,6 @@ public class TokenSourceComponentConfigEditor : Editor
         EditorGUILayout.PropertyField(serializedObject.FindProperty("_participantAttributes"), true);
         EditorGUILayout.PropertyField(serializedObject.FindProperty("_agentName"));
         EditorGUILayout.PropertyField(serializedObject.FindProperty("_agentMetadata"));
+        EditorGUILayout.PropertyField(serializedObject.FindProperty("_agentDeployment"));
     }
 }

--- a/Runtime/Scripts/TokenSource/TokenSource.cs
+++ b/Runtime/Scripts/TokenSource/TokenSource.cs
@@ -140,7 +140,7 @@ namespace LiveKit
                     request.ParticipantAttributes = null;
             }
 
-            if (!string.IsNullOrEmpty(options.AgentName) || !string.IsNullOrEmpty(options.AgentMetadata))
+            if (!string.IsNullOrEmpty(options.AgentName) || !string.IsNullOrEmpty(options.AgentMetadata) || !string.IsNullOrEmpty(options.AgentDeployment))
             {
                 request.RoomConfig = new RoomConfig
                 {
@@ -149,7 +149,8 @@ namespace LiveKit
                         new AgentDispatch
                         {
                             AgentName = NullIfEmpty(options.AgentName),
-                            Metadata = NullIfEmpty(options.AgentMetadata)
+                            Metadata = NullIfEmpty(options.AgentMetadata),
+                            Deployment = NullIfEmpty(options.AgentDeployment)
                         }
                     }
                 };

--- a/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
@@ -107,6 +107,7 @@ namespace LiveKit
                 ParticipantAttributes = participantAttributes,
                 AgentName = Coalesce(options?.AgentName, config.AgentName),
                 AgentMetadata = Coalesce(options?.AgentMetadata, config.AgentMetadata),
+                AgentDeployment = Coalesce(options?.AgentDeployment, config.AgentDeployment),
             };
         }
 

--- a/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
@@ -42,6 +42,7 @@ namespace LiveKit
         [SerializeField] private List<StringPair> _participantAttributes;
         [SerializeField] private string _agentName;
         [SerializeField] private string _agentMetadata;
+        [SerializeField] private string _agentDeployment;
 
         public TokenSourceType TokenSourceType => _tokenSourceType;
 
@@ -64,6 +65,7 @@ namespace LiveKit
         public List<StringPair> ParticipantAttributes => _participantAttributes;
         public string AgentName => _agentName;
         public string AgentMetadata => _agentMetadata;
+        public string AgentDeployment => _agentDeployment;
 
         public bool IsValid => _tokenSourceType switch
         {

--- a/Runtime/Scripts/TokenSource/TokenSourceData.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceData.cs
@@ -15,6 +15,10 @@ namespace LiveKit
         public Dictionary<string, string> ParticipantAttributes { get; init; }
         public string AgentName { get; init; }
         public string AgentMetadata { get; init; }
+        /// <summary>
+        /// Optional deployment to target. Leave empty to target the production deployment.
+        /// </summary>
+        public string AgentDeployment { get; init; }
     }
 
     class TokenSourceRequest
@@ -51,6 +55,12 @@ namespace LiveKit
 
         [JsonProperty("metadata", NullValueHandling = NullValueHandling.Ignore)]
         public string Metadata;
+
+        /// <summary>
+        /// Optional deployment to target. Leave empty to target the production deployment.
+        /// </summary>
+        [JsonProperty("deployment", NullValueHandling = NullValueHandling.Ignore)]
+        public string Deployment;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add `AgentDeployment` property to `TokenSourceFetchOptions` for specifying target deployment
- Add `Deployment` field to `AgentDispatch` class with JSON serialization
- Update `BuildRequest()` to include deployment when any agent field is set

Leave deployment empty to target the production deployment.

## Related PRs
- node-sdks: https://github.com/livekit/server-sdk-js/pull/675
- client-sdk-js: https://github.com/livekit/client-sdk-js/pull/1971
- client-sdk-swift: https://github.com/livekit/client-sdk-swift/pull/1043
- client-sdk-flutter: https://github.com/livekit/client-sdk-flutter/pull/1111
- client-sdk-android: https://github.com/livekit/client-sdk-android/pull/968

## Verification Steps
1. Create a Unity project with the LiveKit SDK
2. Use `TokenSourceEndpoint` or `TokenSourceSandbox` with `TokenSourceFetchOptions`:
   ```csharp
   var options = new TokenSourceFetchOptions
   {
       RoomName = "test-room",
       ParticipantIdentity = "user-1",
       AgentName = "my-agent",
       AgentDeployment = "staging"  // New field
   };
   var details = await tokenSource.FetchConnectionDetails(options);
   ```
3. Verify the JSON request includes `"deployment": "staging"` in the agent dispatch
4. Test with empty deployment (production default)

🤖 Generated with [Claude Code](https://claude.ai/code)