### PR TITLE
Expose DisconnectReason on Room

### DIFF
--- a/Runtime/Scripts/Room.cs
+++ b/Runtime/Scripts/Room.cs
@@ -126,6 +126,8 @@ namespace LiveKit
         public delegate void SipDtmfDelegate(Participant participant, UInt32 code, string digit);
         public delegate void ConnectionStateChangeDelegate(ConnectionState connectionState);
         public delegate void ConnectionDelegate(Room room);
+        public delegate void DisconnectDelegate(Room room, DisconnectReason reason);
+        public delegate void ParticipantDisconnectDelegate(Participant participant, DisconnectReason reason);
         public delegate void E2EeStateChangedDelegate(Participant participant, EncryptionState state);
         public delegate void DataTrackPublishedDelegate(RemoteDataTrack track);
         public delegate void DataTrackUnpublishedDelegate(string sid);
@@ -137,11 +139,13 @@ namespace LiveKit
         public LocalParticipant LocalParticipant { private set; get; }
         public ConnectionState ConnectionState { private set; get; }
         public bool IsConnected => RoomHandle != null && ConnectionState != ConnectionState.ConnDisconnected;
+        public DisconnectReason DisconnectReason { private set; get; }
         public E2EEManager E2EEManager { internal set; get; }
         public IReadOnlyDictionary<string, RemoteParticipant> RemoteParticipants => _participants;
 
         public event ParticipantDelegate ParticipantConnected;
         public event ParticipantDelegate ParticipantDisconnected;
+        public event ParticipantDisconnectDelegate ParticipantDisconnectedWithReason;
         public event LocalPublishDelegate LocalTrackPublished;
         public event LocalPublishDelegate LocalTrackUnpublished;
         public event PublishDelegate TrackPublished;
@@ -157,6 +161,7 @@ namespace LiveKit
         public event ConnectionStateChangeDelegate ConnectionStateChanged;
         public event ConnectionDelegate Connected;
         public event ConnectionDelegate Disconnected;
+        public event DisconnectDelegate DisconnectedWithReason;
         public event ConnectionDelegate Reconnecting;
         public event ConnectionDelegate Reconnected;
         public event E2EeStateChangedDelegate E2EeStateChanged;
@@ -366,6 +371,7 @@ namespace LiveKit
                         var participant = RemoteParticipants[sid];
                         _participants.Remove(sid);
                         ParticipantDisconnected?.Invoke(participant);
+                        ParticipantDisconnectedWithReason?.Invoke(participant, e.ParticipantDisconnected.DisconnectReason);
                     }
                     break;
                 case RoomEvent.MessageOneofCase.TrackPublished:
@@ -536,7 +542,9 @@ namespace LiveKit
                     ConnectionStateChanged?.Invoke(e.ConnectionStateChanged.State);
                     break;
                 case RoomEvent.MessageOneofCase.Disconnected:
+                    DisconnectReason = e.Disconnected.Reason;
                     Disconnected?.Invoke(this);
+                    DisconnectedWithReason?.Invoke(this, DisconnectReason);
                     OnDisconnect();
                     break;
                 case RoomEvent.MessageOneofCase.Reconnecting:

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -229,7 +229,8 @@ public class MeetManager : MonoBehaviour
         _room.TrackMuted += OnTrackMuted;
         _room.TrackUnmuted += OnTrackUnmuted;
         _room.ParticipantConnected += OnParticipantConnected;
-        _room.ParticipantDisconnected += OnParticipantDisconnected;
+        _room.ParticipantDisconnectedWithReason += OnParticipantDisconnected;
+        _room.Disconnected += OnDisconnected;
         _room.DataReceived += OnDataReceived;
 
         var connect = _room.Connect(details.ServerUrl, details.ParticipantToken, new RoomOptions());
@@ -400,8 +401,10 @@ public class MeetManager : MonoBehaviour
     private void OnParticipantConnected(Participant participant)
         => EnsureParticipantTile(participant.Identity);
 
-    private void OnParticipantDisconnected(Participant participant)
+    private void OnParticipantDisconnected(Participant participant, DisconnectReason reason)
     {
+        Debug.Log($"Participant {participant.Identity} disconnected: {reason}");
+
         var owned = new List<string>();
         foreach (var kv in _extraVideoOwners)
             if (kv.Value == participant.Identity) owned.Add(kv.Key);
@@ -409,6 +412,9 @@ public class MeetManager : MonoBehaviour
 
         DestroyParticipantTile(participant.Identity);
     }
+
+    private void OnDisconnected(Room room)
+        => Debug.Log($"Disconnected from room: {room.DisconnectReason}");
 
     private void OnTrackMuted(TrackPublication publication, Participant participant)
     {

--- a/Tests/EditMode/RoomDisconnectReasonTests.cs
+++ b/Tests/EditMode/RoomDisconnectReasonTests.cs
@@ -1,0 +1,87 @@
+using System;
+using LiveKit.Internal;
+using LiveKit.Proto;
+using NUnit.Framework;
+
+namespace LiveKit.EditModeTests
+{
+    // Drives Room.OnEventReceived with synthetic FFI events to verify that the
+    // DisconnectReason carried by the native layer is surfaced through the public
+    // API. A zero FfiHandle is treated as invalid by the SafeHandle, so disposal
+    // is a no-op and no native FFI drop is attempted; matching the event's
+    // RoomHandle to it (also 0) lets OnEventReceived process the event.
+    public class RoomDisconnectReasonTests
+    {
+        [Test]
+        public void DisconnectReason_DefaultsToUnknown()
+        {
+            var room = new Room();
+            Assert.AreEqual(DisconnectReason.UnknownReason, room.DisconnectReason);
+        }
+
+        [Test]
+        public void Disconnected_SurfacesReasonOnPropertyAndEvent()
+        {
+            var room = new Room();
+            room.RoomHandle = new FfiHandle(IntPtr.Zero);
+
+            DisconnectReason? eventReason = null;
+            Room eventRoom = null;
+            room.DisconnectedWithReason += (r, reason) =>
+            {
+                eventRoom = r;
+                eventReason = reason;
+            };
+
+            room.OnEventReceived(new RoomEvent
+            {
+                RoomHandle = 0,
+                Disconnected = new Disconnected { Reason = DisconnectReason.ServerShutdown }
+            });
+
+            Assert.AreEqual(DisconnectReason.ServerShutdown, room.DisconnectReason,
+                "Room.DisconnectReason should reflect the reason from the FFI event.");
+            Assert.AreEqual(DisconnectReason.ServerShutdown, eventReason,
+                "DisconnectedWithReason should fire carrying the reason.");
+            Assert.AreSame(room, eventRoom);
+        }
+
+        [Test]
+        public void ParticipantDisconnected_SurfacesReasonOnEvent()
+        {
+            var room = new Room();
+            room.RoomHandle = new FfiHandle(IntPtr.Zero);
+
+            const string identity = "remote-participant";
+            // Id 0 -> invalid FfiHandle, so the participant carries no live native handle.
+            room.CreateRemoteParticipant(new OwnedParticipant
+            {
+                Handle = new FfiOwnedHandle { Id = 0 },
+                Info = new ParticipantInfo { Identity = identity }
+            });
+
+            DisconnectReason? eventReason = null;
+            Participant eventParticipant = null;
+            room.ParticipantDisconnectedWithReason += (participant, reason) =>
+            {
+                eventParticipant = participant;
+                eventReason = reason;
+            };
+
+            room.OnEventReceived(new RoomEvent
+            {
+                RoomHandle = 0,
+                ParticipantDisconnected = new ParticipantDisconnected
+                {
+                    ParticipantIdentity = identity,
+                    DisconnectReason = DisconnectReason.ParticipantRemoved
+                }
+            });
+
+            Assert.AreEqual(DisconnectReason.ParticipantRemoved, eventReason,
+                "ParticipantDisconnectedWithReason should fire carrying the reason.");
+            Assert.IsNotNull(eventParticipant);
+            Assert.AreEqual(identity, eventParticipant.Identity);
+        }
+    }
+}

--- a/Tests/EditMode/RoomDisconnectReasonTests.cs.meta
+++ b/Tests/EditMode/RoomDisconnectReasonTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57b33d3610cd4a83992cb05cb2428e65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

The `Disconnected` and `ParticipantDisconnected` FFI events already carry a `DisconnectReason`, but it was dropped before reaching the public C# API — there was no way to read why a room or participant disconnected.

This surfaces it without breaking existing subscribers:

- **`Room.DisconnectReason`** property, set immediately before the `Disconnected` event fires.
- **`Room.DisconnectedWithReason`** event `(Room, DisconnectReason)` alongside the existing parameterless `Disconnected`.
- **`Room.ParticipantDisconnectedWithReason`** event `(Participant, DisconnectReason)` alongside the existing `ParticipantDisconnected`.
- Meet sample wired up to log the reason on both room and participant disconnect.

Existing `Disconnected` / `ParticipantDisconnected` signatures are unchanged, so current code keeps compiling.

## Usage

```csharp
room.Disconnected += r => Debug.Log($"Disconnected: {r.DisconnectReason}");
room.ParticipantDisconnectedWithReason += (p, reason) =>
    Debug.Log($"{p.Identity} left: {reason}");
```

## Testing

Project opens and compiles cleanly in Unity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)