### PR TITLE
Add Windows FFI build support to build_ffi_locally.sh

### DIFF
--- a/Scripts~/build_ffi_locally.sh
+++ b/Scripts~/build_ffi_locally.sh
@@ -15,9 +15,11 @@ usage() {
     echo "Usage: $0 <platform> [build_type]"
     echo ""
     echo "Platforms:"
-    echo "  macos       Build for aarch64-apple-darwin"
-    echo "  android     Build for aarch64-linux-android"
-    echo "  ios         Build for aarch64-apple-ios"
+    echo "  macos          Build for aarch64-apple-darwin"
+    echo "  android        Build for aarch64-linux-android"
+    echo "  ios            Build for aarch64-apple-ios"
+    echo "  windows        Build for x86_64-pc-windows-msvc"
+    echo "  windows-arm64  Build for aarch64-pc-windows-msvc"
     echo ""
     echo "Build types (optional, defaults to 'debug'):"
     echo "  release     Optimized release build"
@@ -97,6 +99,35 @@ case "$PLATFORM" in
 
         SRC="$BASE_TARGET/aarch64-apple-ios/$BUILD_DIR/liblivekit_ffi.a"
         DST="$BASE_DST/ffi-ios-arm64/liblivekit_ffi.a"
+        ;;
+    # WINDOWS (x86_64)
+    windows)
+        echo "Building for Windows (x86_64-pc-windows-msvc) [$BUILD_TYPE]..."
+        cargo build \
+            --manifest-path "$MANIFEST" \
+            $BUILD_FLAG \
+            -p livekit-ffi \
+            --target x86_64-pc-windows-msvc
+        BUILD_STATUS=$?
+
+        SRC="$BASE_TARGET/x86_64-pc-windows-msvc/$BUILD_DIR/livekit_ffi.dll"
+        DST="$BASE_DST/ffi-windows-x86_64/livekit_ffi.dll"
+        ;;
+    # WINDOWS (arm64)
+    windows-arm64)
+        echo "Building for Windows (aarch64-pc-windows-msvc) [$BUILD_TYPE]..."
+        # ring 0.16 is incompatible with win aarch64, so use native-tls
+        cargo build \
+            --manifest-path "$MANIFEST" \
+            $BUILD_FLAG \
+            -p livekit-ffi \
+            --target aarch64-pc-windows-msvc \
+            --no-default-features \
+            --features "native-tls"
+        BUILD_STATUS=$?
+
+        SRC="$BASE_TARGET/aarch64-pc-windows-msvc/$BUILD_DIR/livekit_ffi.dll"
+        DST="$BASE_DST/ffi-windows-arm64/livekit_ffi.dll"
         ;;
     *)
         echo -e "${RED}Error: Unknown platform '$PLATFORM'.${RESET}"


### PR DESCRIPTION
## Summary
Adds Windows targets to `Scripts~/build_ffi_locally.sh`, mirroring the Windows build matrix in the Rust SDK's `client-sdk-rust~/.github/workflows/ffi-builds.yml`.

New platforms:
- **`windows`** → `x86_64-pc-windows-msvc`, plain build → `Runtime/Plugins/ffi-windows-x86_64/livekit_ffi.dll`
- **`windows-arm64`** → `aarch64-pc-windows-msvc` with `--no-default-features --features "native-tls"` (ring 0.16 is incompatible with win aarch64) → `Runtime/Plugins/ffi-windows-arm64/livekit_ffi.dll`

Output artifact is `livekit_ffi.dll` (no `lib` prefix, unlike the Unix variants).

## Notes
- Follows the script's existing conventions (`--release`/debug flag, `-p livekit-ffi --manifest-path`) rather than CI's `--profile`/`cd livekit-ffi` form.
- Building these MSVC targets locally requires a Windows shell with bash (Git Bash / MSYS2), the MSVC toolchain, and `rustup target add` for the target. Cross-compiling from macOS won't work for MSVC targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)