### PR TITLE
Max/meet active speaker highlight

### DIFF
--- a/Samples~/Meet/Assets/Prefabs/ParticipantTile.prefab
+++ b/Samples~/Meet/Assets/Prefabs/ParticipantTile.prefab
@@ -1,5 +1,269 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1079504369891404761
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4178691376024653421}
+  m_Layer: 0
+  m_Name: SpeakingBorder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &4178691376024653421
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1079504369891404761}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4014654099764828175}
+  - {fileID: 4181590873099476966}
+  - {fileID: 2801589968853017030}
+  - {fileID: 774622140535728285}
+  m_Father: {fileID: 1555917188056391454}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1975847642458181108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2801589968853017030}
+  - component: {fileID: 2589623236477187243}
+  - component: {fileID: 1584975685953281}
+  m_Layer: 0
+  m_Name: Edge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2801589968853017030
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1975847642458181108}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4178691376024653421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 3, y: 0}
+  m_SizeDelta: {x: 6, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2589623236477187243
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1975847642458181108}
+  m_CullTransparentMesh: 1
+--- !u!114 &1584975685953281
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1975847642458181108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2, g: 0.78, b: 0.4, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2127998796310192455
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 774622140535728285}
+  - component: {fileID: 1883271954264915863}
+  - component: {fileID: 1465583170198967143}
+  m_Layer: 0
+  m_Name: Edge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &774622140535728285
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2127998796310192455}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4178691376024653421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -3, y: 0}
+  m_SizeDelta: {x: 6, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1883271954264915863
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2127998796310192455}
+  m_CullTransparentMesh: 1
+--- !u!114 &1465583170198967143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2127998796310192455}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2, g: 0.78, b: 0.4, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2674131352550868656
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4181590873099476966}
+  - component: {fileID: 7658326356064874384}
+  - component: {fileID: 1861815905292574992}
+  m_Layer: 0
+  m_Name: Edge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4181590873099476966
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2674131352550868656}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4178691376024653421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 3}
+  m_SizeDelta: {x: 0, y: 6}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7658326356064874384
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2674131352550868656}
+  m_CullTransparentMesh: 1
+--- !u!114 &1861815905292574992
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2674131352550868656}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2, g: 0.78, b: 0.4, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3194821530047289010
 GameObject:
   m_ObjectHideFlags: 0
@@ -134,6 +398,81 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &3846964182422509708
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4014654099764828175}
+  - component: {fileID: 7200332312166234127}
+  - component: {fileID: 1472620736581854003}
+  m_Layer: 0
+  m_Name: Edge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4014654099764828175
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3846964182422509708}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4178691376024653421}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -3}
+  m_SizeDelta: {x: 0, y: 6}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7200332312166234127
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3846964182422509708}
+  m_CullTransparentMesh: 1
+--- !u!114 &1472620736581854003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3846964182422509708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2, g: 0.78, b: 0.4, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6893859239230208018
 GameObject:
   m_ObjectHideFlags: 0
@@ -320,6 +659,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5473313263338453555}
+  - {fileID: 4178691376024653421}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -342,6 +682,7 @@ MonoBehaviour:
   Image: {fileID: 1456447410953633226}
   Label: {fileID: 5296510187475739508}
   MicIcon: {fileID: 2212814851375317419}
+  SpeakingBorder: {fileID: 4178691376024653421}
 --- !u!222 &6927542484225957466
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Samples~/Meet/Assets/Runtime/MeetManager.cs
+++ b/Samples~/Meet/Assets/Runtime/MeetManager.cs
@@ -58,6 +58,7 @@ public class MeetManager : MonoBehaviour
     private readonly Dictionary<string, string> _extraVideoOwners = new();
     private readonly Dictionary<string, GameObject> _audioObjects = new();
     private readonly Dictionary<string, VideoStream> _videoStreams = new();
+    private readonly HashSet<string> _speakingIdentities = new();
 
     private readonly Dictionary<string, AudioStream> _audioStreams = new();
 
@@ -231,6 +232,7 @@ public class MeetManager : MonoBehaviour
         _room.ParticipantConnected += OnParticipantConnected;
         _room.ParticipantDisconnected += OnParticipantDisconnected;
         _room.DataReceived += OnDataReceived;
+        _room.ActiveSpeakersChanged += OnActiveSpeakersChanged;
 
         var connect = _room.Connect(details.ServerUrl, details.ParticipantToken, new RoomOptions());
         yield return connect;
@@ -395,6 +397,23 @@ public class MeetManager : MonoBehaviour
     {
         var message = System.Text.Encoding.Default.GetString(data);
         Debug.Log($"DataReceived from {participant.Identity}: {message}");
+    }
+
+    private void OnActiveSpeakersChanged(List<Participant> speakers)
+    {
+        // The SDK delivers the complete set of currently-speaking participants each
+        // time, so anyone previously speaking but absent here has stopped.
+        foreach (var identity in _speakingIdentities)
+            if (_participantTiles.TryGetValue(identity, out var tile))
+                tile.SetSpeaking(false);
+
+        _speakingIdentities.Clear();
+        foreach (var participant in speakers)
+        {
+            _speakingIdentities.Add(participant.Identity);
+            if (_participantTiles.TryGetValue(participant.Identity, out var tile))
+                tile.SetSpeaking(true);
+        }
     }
 
     private void OnParticipantConnected(Participant participant)
@@ -757,6 +776,8 @@ public class MeetManager : MonoBehaviour
         }
         _extraVideoTiles.Clear();
         _extraVideoOwners.Clear();
+
+        _speakingIdentities.Clear();
 
         _cameraActive = false;
         _microphoneActive = false;

--- a/Samples~/Meet/Assets/Runtime/ParticipantTile.cs
+++ b/Samples~/Meet/Assets/Runtime/ParticipantTile.cs
@@ -9,9 +9,16 @@ public class ParticipantTile : MonoBehaviour
     public TMP_Text Label;
     public MaterialIcon MicIcon;
 
+    [Header("Speaking highlight")]
+    [SerializeField] private Color speakingColor = new Color(0.2f, 0.78f, 0.4f, 1f);
+    [SerializeField] private float speakingBorderThickness = 6f;
+
     private ResizeTextureController _controller;
     private Texture _placeholder;
     private bool _showingLive;
+
+    private RectTransform _speakingBorder;
+    private bool _speaking;
 
     private void Awake()
     {
@@ -66,6 +73,64 @@ public class ParticipantTile : MonoBehaviour
     {
         if (MicIcon == null) return;
         MicIcon.gameObject.SetActive(muted);
+    }
+
+    /// <summary>
+    /// Highlights the tile with a colored border while the participant is speaking.
+    /// The border is built lazily on first use, so no prefab wiring is required.
+    /// </summary>
+    public void SetSpeaking(bool speaking)
+    {
+        if (_speaking == speaking) return;
+        _speaking = speaking;
+
+        if (_speakingBorder == null)
+        {
+            if (!speaking) return;
+            _speakingBorder = CreateSpeakingBorder();
+        }
+
+        _speakingBorder.gameObject.SetActive(speaking);
+    }
+
+    private RectTransform CreateSpeakingBorder()
+    {
+        var container = new GameObject("SpeakingBorder", typeof(RectTransform));
+        var rt = (RectTransform)container.transform;
+        rt.SetParent(transform, false);
+        rt.anchorMin = Vector2.zero;
+        rt.anchorMax = Vector2.one;
+        rt.offsetMin = Vector2.zero;
+        rt.offsetMax = Vector2.zero;
+        rt.SetAsLastSibling(); // draw on top of the video and the label
+
+        float t = speakingBorderThickness;
+        // top
+        AddEdge(rt, new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, -t), Vector2.zero);
+        // bottom
+        AddEdge(rt, new Vector2(0, 0), new Vector2(1, 0), Vector2.zero, new Vector2(0, t));
+        // left
+        AddEdge(rt, new Vector2(0, 0), new Vector2(0, 1), Vector2.zero, new Vector2(t, 0));
+        // right
+        AddEdge(rt, new Vector2(1, 0), new Vector2(1, 1), new Vector2(-t, 0), Vector2.zero);
+
+        return rt;
+    }
+
+    private void AddEdge(RectTransform parent, Vector2 anchorMin, Vector2 anchorMax,
+        Vector2 offsetMin, Vector2 offsetMax)
+    {
+        var edge = new GameObject("Edge", typeof(RectTransform), typeof(Image));
+        var rt = (RectTransform)edge.transform;
+        rt.SetParent(parent, false);
+        rt.anchorMin = anchorMin;
+        rt.anchorMax = anchorMax;
+        rt.offsetMin = offsetMin;
+        rt.offsetMax = offsetMax;
+
+        var image = edge.GetComponent<Image>();
+        image.color = speakingColor;
+        image.raycastTarget = false;
     }
 
     private void Update() => _controller?.Resize();

--- a/Samples~/Meet/Assets/Runtime/ParticipantTile.cs
+++ b/Samples~/Meet/Assets/Runtime/ParticipantTile.cs
@@ -8,16 +8,12 @@ public class ParticipantTile : MonoBehaviour
     public RawImage Image;
     public TMP_Text Label;
     public MaterialIcon MicIcon;
-
-    [Header("Speaking highlight")]
-    [SerializeField] private Color speakingColor = new Color(0.2f, 0.78f, 0.4f, 1f);
-    [SerializeField] private float speakingBorderThickness = 6f;
+    public RectTransform SpeakingBorder;
 
     private ResizeTextureController _controller;
     private Texture _placeholder;
     private bool _showingLive;
 
-    private RectTransform _speakingBorder;
     private bool _speaking;
 
     private void Awake()
@@ -84,53 +80,7 @@ public class ParticipantTile : MonoBehaviour
         if (_speaking == speaking) return;
         _speaking = speaking;
 
-        if (_speakingBorder == null)
-        {
-            if (!speaking) return;
-            _speakingBorder = CreateSpeakingBorder();
-        }
-
-        _speakingBorder.gameObject.SetActive(speaking);
-    }
-
-    private RectTransform CreateSpeakingBorder()
-    {
-        var container = new GameObject("SpeakingBorder", typeof(RectTransform));
-        var rt = (RectTransform)container.transform;
-        rt.SetParent(transform, false);
-        rt.anchorMin = Vector2.zero;
-        rt.anchorMax = Vector2.one;
-        rt.offsetMin = Vector2.zero;
-        rt.offsetMax = Vector2.zero;
-        rt.SetAsLastSibling(); // draw on top of the video and the label
-
-        float t = speakingBorderThickness;
-        // top
-        AddEdge(rt, new Vector2(0, 1), new Vector2(1, 1), new Vector2(0, -t), Vector2.zero);
-        // bottom
-        AddEdge(rt, new Vector2(0, 0), new Vector2(1, 0), Vector2.zero, new Vector2(0, t));
-        // left
-        AddEdge(rt, new Vector2(0, 0), new Vector2(0, 1), Vector2.zero, new Vector2(t, 0));
-        // right
-        AddEdge(rt, new Vector2(1, 0), new Vector2(1, 1), new Vector2(-t, 0), Vector2.zero);
-
-        return rt;
-    }
-
-    private void AddEdge(RectTransform parent, Vector2 anchorMin, Vector2 anchorMax,
-        Vector2 offsetMin, Vector2 offsetMax)
-    {
-        var edge = new GameObject("Edge", typeof(RectTransform), typeof(Image));
-        var rt = (RectTransform)edge.transform;
-        rt.SetParent(parent, false);
-        rt.anchorMin = anchorMin;
-        rt.anchorMax = anchorMax;
-        rt.offsetMin = offsetMin;
-        rt.offsetMax = offsetMax;
-
-        var image = edge.GetComponent<Image>();
-        image.color = speakingColor;
-        image.raycastTarget = false;
+        SpeakingBorder.gameObject.SetActive(speaking);
     }
 
     private void Update() => _controller?.Resize();

--- a/Samples~/Meet/Assets/Runtime/ParticipantTile.cs
+++ b/Samples~/Meet/Assets/Runtime/ParticipantTile.cs
@@ -73,7 +73,6 @@ public class ParticipantTile : MonoBehaviour
 
     /// <summary>
     /// Highlights the tile with a colored border while the participant is speaking.
-    /// The border is built lazily on first use, so no prefab wiring is required.
     /// </summary>
     public void SetSpeaking(bool speaking)
     {


### PR DESCRIPTION
### Background

Adds a green speaker boarder around the participant tile if participant is an active speaker. 

### Changes

What did you do?

- Using OnActiveSpeakersChanged to query for active speaker
- Set boarder active accordingly

### Example

<img width="390" height="820" alt="Screenshot 2026-06-24 at 16 49 25" src="https://github.com/user-attachments/assets/a0734278-5b8f-42e3-aa7f-f1c47e592608" />
