### PR TITLE
Set dynacast to false per default

### DIFF
--- a/Runtime/Scripts/Core/Room.cs
+++ b/Runtime/Scripts/Core/Room.cs
@@ -88,7 +88,7 @@ namespace LiveKit
     {
         public bool AutoSubscribe = true;
         public bool Dynacast = false;
-        public bool AdaptiveStream = true;
+        public bool AdaptiveStream = false;
         public uint JoinRetries = 3;
         public RTCConfiguration RtcConfig = null;
         public E2EEOptions E2EE = null;

--- a/Runtime/Scripts/Core/Room.cs
+++ b/Runtime/Scripts/Core/Room.cs
@@ -87,7 +87,7 @@ namespace LiveKit
     public class RoomOptions
     {
         public bool AutoSubscribe = true;
-        public bool Dynacast = true;
+        public bool Dynacast = false;
         public bool AdaptiveStream = true;
         public uint JoinRetries = 3;
         public RTCConfiguration RtcConfig = null;

--- a/Tests/PlayMode/Utils/TestRoomContext.cs
+++ b/Tests/PlayMode/Utils/TestRoomContext.cs
@@ -42,7 +42,6 @@ namespace LiveKit.PlayModeTests.Utils
             public bool CanSubscribe;
             public bool CanUpdateOwnMetadata;
             public string ServerUrl;
-            public bool Dynacast;
 
             public static ConnectionOptions Default => new ConnectionOptions
             {
@@ -51,7 +50,6 @@ namespace LiveKit.PlayModeTests.Utils
                 CanPublish = true,
                 CanPublishData = true,
                 CanSubscribe = true,
-                Dynacast = true,
             };
         }
 
@@ -69,7 +67,7 @@ namespace LiveKit.PlayModeTests.Utils
             ConnectionOptions options = _connectionOptions[index];
             var room = Rooms[index];
             var token = CreateToken(options);
-            var roomOptions = new RoomOptions { Dynacast = options.Dynacast };
+            var roomOptions = new RoomOptions();
             var connect = room.Connect(options.ServerUrl ?? _serverUrl, token, roomOptions);
             yield return connect;
 

--- a/Tests/PlayMode/VideoFrameMetadataTests.cs
+++ b/Tests/PlayMode/VideoFrameMetadataTests.cs
@@ -19,7 +19,6 @@ namespace LiveKit.PlayModeTests
             // calling sender.set_parameters(), which drops the sender's encoder->packetizer
             // frame-metadata transformer. Disabling it on the publisher should let metadata
             // arrive. See rust-sdks #1003.
-            publisher.Dynacast = false;
             var subscriber = TestRoomContext.ConnectionOptions.Default;
             subscriber.Identity = "metadata-subscriber";
             return (publisher, subscriber);


### PR DESCRIPTION
### Background

Dynacast is off per default in Rust SDK, so set it off per default in Unity SDK.
Also adaptive streaming is off in Rust SDK per default.
