### PR TITLE
Fix dropped first chunk in incremental stream readers

### DIFF
--- a/Runtime/Scripts/DataStreams/ByteDataStream.cs
+++ b/Runtime/Scripts/DataStreams/ByteDataStream.cs
@@ -83,9 +83,14 @@ namespace LiveKit
             using var request = FFIBridge.Instance.NewRequest<ByteStreamReaderReadIncrementalRequest>();
             var readIncReq = request.request;
             readIncReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
-            request.Send();
 
-            return new ReadIncrementalInstruction(_handle);
+            // Subscribe before sending: chunk events are delivered directly on the FFI
+            // callback thread, and the FFI server emits already-buffered chunks as soon
+            // as it receives the request. Sending first loses any chunk emitted before
+            // the subscription exists.
+            var instruction = new ReadIncrementalInstruction(_handle);
+            request.Send();
+            return instruction;
         }
 
         /// <summary>

--- a/Runtime/Scripts/DataStreams/TextDataStream.cs
+++ b/Runtime/Scripts/DataStreams/TextDataStream.cs
@@ -122,9 +122,14 @@ namespace LiveKit
             using var request = FFIBridge.Instance.NewRequest<TextStreamReaderReadIncrementalRequest>();
             var readIncReq = request.request;
             readIncReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
-            request.Send();
 
-            return new ReadIncrementalInstruction(_handle);
+            // Subscribe before sending: chunk events are delivered directly on the FFI
+            // callback thread, and the FFI server emits already-buffered chunks as soon
+            // as it receives the request. Sending first loses any chunk emitted before
+            // the subscription exists.
+            var instruction = new ReadIncrementalInstruction(_handle);
+            request.Send();
+            return instruction;
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem

Agent transcriptions were intermittently missing the first word(s) of a reply.

`TextStreamReader.ReadIncremental()` (and the byte-stream equivalent) sent the FFI request **before** constructing the `ReadIncrementalInstruction` whose constructor subscribes to `TextStreamReaderEventReceived`. Three facts turn that ordering into a real chunk drop:

1. The Rust FFI server spawns a task that drains already-buffered chunks the moment it receives the `read_incremental` request (`livekit-ffi/src/server/data_stream.rs`). By the time the app calls `ReadIncremental()`, the first chunk of an agent reply has typically already arrived and is buffered — the stream-open event took a main-thread hop to reach the handler.
2. `FFIClient.RouteFfiEvent` invokes `TextStreamReaderEventReceived` directly on the FFI callback thread (no main-thread queueing), so the first chunk event races the remainder of `ReadIncremental()` on the main thread.
3. Events fired before the subscription exists are silently lost — the pending-chunk queue in `ReadIncrementalInstructionBase` only buffers chunks that arrive after subscription.

When the Rust task won the race, the first chunk was gone. For delta text streams (agent transcriptions via `lk.transcription`) that means the first word(s) of the reply never render. `ReadAll()` already used the safe order, which is why snapshot-style streams were unaffected.

## Fix

Construct the instruction (subscribing to reader events) before sending the request, in both `TextStreamReader.ReadIncremental()` and `ByteStreamReader.ReadIncremental()`. C# event add/invoke is an atomic delegate swap, so subscribing first is sufficient; chunks arriving before the first yield are already handled by the pending-chunk queue.

## Result

No more first chunks missing in my agent sample transcription.