### PR TITLE
Guarding for iOS and Unity editor case

### DIFF
--- a/Runtime/Scripts/Internal/FFI/NativeMethods.cs
+++ b/Runtime/Scripts/Internal/FFI/NativeMethods.cs
@@ -10,7 +10,7 @@ namespace LiveKit.Internal.FFI
     [SuppressUnmanagedCodeSecurity]
     internal static class NativeMethods
     {
-        #if UNITY_IOS
+        #if UNITY_IOS && !UNITY_EDITOR
         const string Lib = "__Internal";
         #else
         const string Lib = "livekit_ffi";


### PR DESCRIPTION
### Background

On Unity 6 when iOS was selected as build target, upon opening the editor there was an error message:
`EntryPointNotFoundException`

Reported here: https://github.com/livekit/client-sdk-unity/issues/338

### Changes

- Guarding native call for editor and iOS build target case