### PR TITLE
Surface FFI panic events instead of silently dropping them

### DIFF
--- a/Runtime/Scripts/Core/Room.cs
+++ b/Runtime/Scripts/Core/Room.cs
@@ -220,6 +220,7 @@ namespace LiveKit
             FfiClient.Instance.RoomEventReceived -= OnEventReceived;
             FfiClient.Instance.RpcMethodInvocationReceived -= OnRpcMethodInvocationReceived;
             FfiClient.Instance.DisconnectReceived -= OnDisconnectReceived;
+            FfiClient.Instance.PanicReceived -= OnPanicReceived;
 
             // Participant + track + publication FFI handles are independent entries in the
             // Rust handle table — dropping the room handle alone does not cascade to them, so
@@ -598,6 +599,7 @@ namespace LiveKit
 
             FfiClient.Instance.RoomEventReceived += OnEventReceived;
             FfiClient.Instance.DisconnectReceived += OnDisconnectReceived;
+            FfiClient.Instance.PanicReceived += OnPanicReceived;
             FfiClient.Instance.RpcMethodInvocationReceived += OnRpcMethodInvocationReceived;
 
             // Signal Rust that listeners are installed and it can start forwarding room events.
@@ -617,6 +619,18 @@ namespace LiveKit
         {
             FfiClient.Instance.DisconnectReceived -= OnDisconnectReceived;
             Utils.Debug($"OnDisconnect.... {e}");
+        }
+
+        private void OnPanicReceived(Panic e)
+        {
+            // A panic means the FFI layer's background tasks may have died: this
+            // room could silently stop receiving events (including Disconnected
+            // itself), so the panic is surfaced through the disconnect path apps
+            // already handle.
+            DisconnectReason = DisconnectReason.UnknownReason;
+            Disconnected?.Invoke(this);
+            DisconnectedWithReason?.Invoke(this, DisconnectReason);
+            OnDisconnect();
         }
 
         private void OnDisconnect()

--- a/Runtime/Scripts/Internal/FFI/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFI/FFIClient.cs
@@ -50,6 +50,7 @@ namespace LiveKit.Internal.FFI
         private readonly ConcurrentDictionary<ulong, PendingCallbackBase> pendingCallbacks = new();
 
         public event DisconnectReceivedDelegate? DisconnectReceived;
+        public event PanicReceivedDelegate? PanicReceived;
         public event RoomEventReceivedDelegate? RoomEventReceived;
         public event TrackEventReceivedDelegate? TrackEventReceived;
         public event RpcMethodInvocationReceivedDelegate? RpcMethodInvocationReceived;
@@ -466,6 +467,15 @@ namespace LiveKit.Internal.FFI
                     Instance.DataTrackStreamEventReceived?.Invoke(ffiEvent.DataTrackStreamEvent!);
                     break;
                 case FfiEvent.MessageOneofCase.Panic:
+                    // The FFI layer declares its state unrecoverable after a panic:
+                    // background tasks may have died, so rooms can silently stop
+                    // receiving events and in-flight requests may never complete.
+                    // Pending callbacks are cancelled before PanicReceived so that
+                    // requests issued by user handlers reacting to the panic (e.g. a
+                    // reconnect attempt from a Disconnected handler) are not swept up.
+                    Utils.Error($"FFI panic: {ffiEvent.Panic.Message} — native SDK state is unrecoverable; cancelling pending requests and disconnecting rooms");
+                    Instance.ClearPendingCallbacks();
+                    Instance.PanicReceived?.Invoke(ffiEvent.Panic);
                     break;
                 default:
                     break;

--- a/Runtime/Scripts/Internal/FFI/FFIEvents.cs
+++ b/Runtime/Scripts/Internal/FFI/FFIEvents.cs
@@ -20,6 +20,8 @@ namespace LiveKit.Internal.FFI
 
     internal delegate void DisconnectReceivedDelegate(DisconnectCallback e);
 
+    internal delegate void PanicReceivedDelegate(Panic e);
+
     internal delegate void GetSessionStatsDelegate(GetStatsCallback e);
 
     internal delegate void SetLocalMetadataReceivedDelegate(SetLocalMetadataCallback e);

--- a/Tests/EditMode/PanicEventTests.cs
+++ b/Tests/EditMode/PanicEventTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading;
+using LiveKit.Proto;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+using LiveKit.Internal.FFI;
+namespace LiveKit.EditModeTests
+{
+    public class PanicEventTests
+    {
+        private sealed class RecordingSyncContext : SynchronizationContext
+        {
+            public readonly List<(SendOrPostCallback callback, object state)> Posts = new();
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                Posts.Add((d, state));
+            }
+            public void DrainOnce()
+            {
+                foreach (var (cb, st) in Posts) cb(st);
+                Posts.Clear();
+            }
+        }
+
+        // Seeded in a different high-bit range than SkipDispatchTests so the two
+        // fixtures cannot collide in FfiClient.Instance's shared pendingCallbacks map.
+        private static long _asyncIdSeed = 0x7FE0_0000_0000_0000L;
+        private static ulong NextAsyncId() => (ulong)Interlocked.Increment(ref _asyncIdSeed);
+
+        [Test]
+        public void RouteFfiEvent_Panic_RaisesPanicReceivedOnMainThread_AndCancelsPendingCallbacks()
+        {
+            var asyncId = NextAsyncId();
+            var completed = false;
+            var canceled = false;
+
+            // Stands in for any in-flight async request (e.g. a pending
+            // ConnectInstruction). After a panic its Rust-side task may be dead,
+            // so it must be cancelled rather than left to hang forever.
+            FfiClient.Instance.RegisterPendingCallback<UnpublishTrackCallback>(
+                asyncId,
+                static e => e.UnpublishTrack,
+                cb => { completed = true; },
+                onCancel: () => { canceled = true; });
+
+            string receivedMessage = null;
+            PanicReceivedDelegate handler = e => receivedMessage = e.Message;
+            FfiClient.Instance.PanicReceived += handler;
+
+            var recording = new RecordingSyncContext();
+            var originalContext = FfiClient.Instance._context;
+            FfiClient.Instance._context = recording;
+            try
+            {
+                LogAssert.Expect(LogType.Error, new Regex("FFI panic"));
+
+                var ev = new FfiEvent { Panic = new Panic { Message = "test panic from FFI" } };
+                var dispatcher = new Thread(() => FfiClient.RouteFfiEvent(ev));
+                dispatcher.Start();
+                Assert.IsTrue(dispatcher.Join(TimeSpan.FromSeconds(2)),
+                    "Dispatcher thread did not finish within 2s.");
+
+                // Panic handling fires user-facing events (room teardown), so it must
+                // be marshalled to the main thread, not run on the FFI callback thread.
+                Assert.AreEqual(1, recording.Posts.Count,
+                    "RouteFfiEvent should post the panic to the main-thread sync context.");
+                Assert.IsNull(receivedMessage,
+                    "PanicReceived ran on the FFI callback thread instead of the main-thread drain.");
+                Assert.IsFalse(canceled,
+                    "Pending callbacks were cancelled before the main-thread drain.");
+
+                recording.DrainOnce();
+
+                Assert.AreEqual("test panic from FFI", receivedMessage,
+                    "PanicReceived did not fire with the panic message.");
+                Assert.IsTrue(canceled,
+                    "Pending callbacks were not cancelled on panic — awaiting instructions would hang forever.");
+                Assert.IsFalse(completed,
+                    "The pending callback completed instead of being cancelled.");
+
+                // The pending entry must be gone: a late callback for it is a no-op.
+                var lateCallback = new FfiEvent
+                {
+                    UnpublishTrack = new UnpublishTrackCallback { AsyncId = asyncId }
+                };
+                Assert.IsFalse(FfiClient.Instance.TryDispatchPendingCallback(asyncId, lateCallback),
+                    "The cancelled pending entry is still registered.");
+            }
+            finally
+            {
+                FfiClient.Instance._context = originalContext;
+                FfiClient.Instance.PanicReceived -= handler;
+                FfiClient.Instance.CancelPendingCallback(asyncId);
+            }
+        }
+    }
+}

--- a/Tests/EditMode/PanicEventTests.cs.meta
+++ b/Tests/EditMode/PanicEventTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43df0c93530a4c698356db201dd39859
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/PlayMode/PanicRoomTeardownTests.cs
+++ b/Tests/PlayMode/PanicRoomTeardownTests.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using System.Text.RegularExpressions;
+using LiveKit.Internal.FFI;
+using LiveKit.PlayModeTests.Utils;
+using LiveKit.Proto;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace LiveKit.PlayModeTests
+{
+    /// <summary>
+    /// An FfiEvent.Panic means the FFI layer's state is unrecoverable — its
+    /// background tasks may have died, leaving rooms that silently stop
+    /// receiving events (they would not even get a Disconnected event). The
+    /// SDK must convert that into an observable disconnect on every live
+    /// room instead of dropping the event.
+    /// </summary>
+    public class PanicRoomTeardownTests
+    {
+        const float DisconnectTimeoutSeconds = 10f;
+
+        [UnityTest, Category("E2E")]
+        public IEnumerator Panic_DisconnectsConnectedRoom()
+        {
+            var options = TestRoomContext.ConnectionOptions.Default;
+            options.Identity = "panic-teardown";
+            using var context = new TestRoomContext(options);
+
+            yield return context.ConnectRoom(0);
+            Assert.IsNull(context.ConnectionError, context.ConnectionError);
+
+            var room = context.Rooms[0];
+            Room disconnectedRoom = null;
+            DisconnectReason? reason = null;
+            room.Disconnected += r => disconnectedRoom = r;
+            room.DisconnectedWithReason += (r, dr) => reason = dr;
+
+            LogAssert.Expect(LogType.Error, new Regex("FFI panic"));
+
+            // Inject a synthetic panic through the same entry point the native
+            // callback uses; it is posted to the main thread like real events.
+            FfiClient.RouteFfiEvent(new FfiEvent
+            {
+                Panic = new Panic { Message = "synthetic panic (test)" }
+            });
+
+            var disconnected = new Expectation(
+                predicate: () => disconnectedRoom != null,
+                timeoutSeconds: DisconnectTimeoutSeconds);
+            yield return disconnected.Wait();
+
+            Assert.IsNull(disconnected.Error,
+                "Room did not raise Disconnected after an FFI panic event.");
+            Assert.AreSame(room, disconnectedRoom,
+                "Disconnected fired for a different room instance.");
+            Assert.AreEqual(DisconnectReason.UnknownReason, reason,
+                "DisconnectedWithReason did not carry the expected reason.");
+            Assert.AreEqual(DisconnectReason.UnknownReason, room.DisconnectReason,
+                "Room.DisconnectReason was not set by the panic teardown.");
+            Assert.IsFalse(room.IsConnected,
+                "Room still reports IsConnected after the panic teardown.");
+        }
+    }
+}

--- a/Tests/PlayMode/PanicRoomTeardownTests.cs.meta
+++ b/Tests/PlayMode/PanicRoomTeardownTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a0a0a2e224f4d30ad6c86b4e578324d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

`FfiEvent.Panic` is the FFI layer's global unrecoverable-error notification, and Unity dropped it on the floor (`DispatchEvent` had `case Panic: break;` — a stub from an early protocol sync that was never wired). This PR surfaces panics through the disconnect path apps already handle.

## What panic events are

The FFI sends `Panic { message }` (no room handle — it's global) from three kinds of places:

1. **A spawned task panicked** — `watch_panic` wraps essentially every FFI task (room event forwarding, stream tasks, the connect task, ...) and forwards the `JoinError`. The Rust comment: *"Recommended behaviour is to exit the process."*
2. **A panic while handling a synchronous request** (`catch_unwind` in `cabi.rs`).
3. **Deliberate `send_panic` for state errors with no callback left to carry them** — currently the ready-handshake timeout, which force-closes a room *after* `ConnectCallback` already went out.

After a panic the FFI's state is unreliable: a room whose event task died silently stops receiving events (including `Disconnected` itself — a zombie room), and in-flight async requests never complete (hung `YieldInstruction`s).

Caveat worth knowing: release FFI binaries build with `panic = "abort"` (workspace `Cargo.toml`), so *genuine* Rust panics crash the process before any event is sent. In shipped builds this wiring covers the deliberate `send_panic` paths — including the ready-timeout zombie-room case — and it covers everything in local debug builds.

## Changes

Since "exit the process" is not acceptable in Unity (Editor / shipped games), the panic becomes an observable disconnect:

- **Log loudly** via `Utils.Error` (works in Editor console and player logs; previously the only trace was a Rust-side `log::error!` that is invisible unless `LK_VERBOSE`).
- **Cancel all pending callbacks** so awaiting instructions (e.g. a mid-flight `ConnectInstruction`) resolve with `IsError` instead of hanging forever. Done *before* raising the event so requests issued by user handlers reacting to the panic (reconnect attempts) are not swept up.
- **New internal `FfiClient.PanicReceived` event**; each connected `Room` subscribes in `OnConnect` and tears itself down through the existing sequence: `Disconnected`, `DisconnectedWithReason(UnknownReason)`, cleanup.

## Tests

- **EditMode `PanicEventTests`**: drives `RouteFfiEvent` with a synthetic panic from a non-main thread; asserts main-thread marshalling, `PanicReceived` payload, pending-callback cancellation (not completion), and entry removal.
- **PlayMode `PanicRoomTeardownTests`** (E2E): connects a real room, injects a synthetic panic through `RouteFfiEvent`, asserts `Disconnected` / `DisconnectedWithReason(UnknownReason)` fire and `IsConnected` goes false.
- `LateJoinTrackSubscriptionTests` re-run as connect-path regression guard.

Also when I remove the `ReadyForRoomEvents` call, the native side panics after 15s.

Before this change: 
<img width="1762" height="359" alt="Screenshot 2026-07-06 at 16 07 50" src="https://github.com/user-attachments/assets/1ccaff6d-89c0-4992-95c4-7f8972956a36" />

After this change:
<img width="1821" height="471" alt="Screenshot 2026-07-06 at 16 05 53" src="https://github.com/user-attachments/assets/5a3bbf66-7f71-47bb-aa5e-d334ce49bd4d" />
