### PR TITLE
Add gated agent-dispatch stress test (100x connect, wait for agent)

### DIFF
--- a/Tests/PlayMode/AgentDispatchStressTests.cs
+++ b/Tests/PlayMode/AgentDispatchStressTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections;
+using System.Linq;
+using LiveKit.Internal.Threading;
+using LiveKit.PlayModeTests.Utils;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace LiveKit.PlayModeTests
+{
+    /// <summary>
+    /// Stress reproduction for field reports of dispatched agents missing from both the
+    /// connect snapshot and the room events delivered after the ReadyForRoomEvent
+    /// handshake. Each iteration fetches fresh connection details from a token source
+    /// whose server dispatches an agent into the room, connects, and requires a remote
+    /// participant of kind Agent to become visible within <see cref="AgentTimeoutSeconds"/>.
+    /// The run stops at the first failure and logs the room sid/name so the failing room
+    /// can be cross-checked against server-side dispatch logs.
+    ///
+    /// The remote-participant check polls <c>Room.RemoteParticipants</c> rather than the
+    /// ParticipantConnected event so an agent delivered via the connect snapshot counts
+    /// the same as one delivered via an event — the bug under investigation is the
+    /// participant being absent from both.
+    ///
+    /// Gated by environment variables so CI (which runs no agent worker) skips it:
+    ///   LK_TEST_AGENT_TOKEN_ENDPOINT — full token endpoint URL, or
+    ///   LK_TEST_AGENT_SANDBOX_ID    — LiveKit Cloud sandbox id.
+    /// </summary>
+    public class AgentDispatchStressTests
+    {
+        const int Iterations = 100;
+        const float AgentTimeoutSeconds = 10f;
+        const int TestTimeoutMs = 30 * 60 * 1000;
+
+        const string SandBoxId = null;
+        const string Endpoint = null;
+        const string AgentName = null;
+
+        [UnityTest, Category("AgentE2E"), Timeout(TestTimeoutMs)]
+        public IEnumerator AgentDispatch_AgentAppearsWithinTimeout_100Iterations()
+        {
+            var tokenSource = CreateTokenSource();
+            if (tokenSource == null)
+            {
+                Assert.Ignore(
+                    "Agent dispatch test skipped: set SandBoxId or " +
+                    "Endpoint to run it.");
+                yield break;
+            }
+
+            LogAssert.ignoreFailingMessages = true;
+            try
+            {
+                for (int i = 1; i <= Iterations; i++)
+                {
+                    var fetch = new TaskYieldInstruction<ConnectionDetails>(
+                        tokenSource.FetchConnectionDetails(new TokenSourceFetchOptions
+                        {
+                            RoomName = $"unity-agent-test-{Guid.NewGuid()}",
+                            ParticipantIdentity = $"unity-agent-test-participant-{i}",
+                            AgentName = AgentName
+                            
+                        }));
+                    yield return fetch;
+                    if (fetch.IsError)
+                        Assert.Fail($"Iteration {i}/{Iterations}: token fetch failed: {fetch.Exception}");
+                    if (string.IsNullOrEmpty(fetch.Result?.ServerUrl) || string.IsNullOrEmpty(fetch.Result?.ParticipantToken))
+                        Assert.Fail($"Iteration {i}/{Iterations}: token source returned incomplete connection details");
+
+                    var room = new Room();
+                    try
+                    {
+                        var connect = room.Connect(fetch.Result.ServerUrl, fetch.Result.ParticipantToken, new RoomOptions());
+                        yield return connect;
+                        if (connect.IsError)
+                            Assert.Fail($"Iteration {i}/{Iterations}: failed to connect");
+
+                        var agentAppeared = new Expectation(
+                            () => room.RemoteParticipants.Values.Any(p => p._info.Kind == Proto.ParticipantKind.Agent),
+                            timeoutSeconds: AgentTimeoutSeconds);
+                        yield return agentAppeared.Wait();
+
+                        if (agentAppeared.Error != null)
+                        {
+                            var participants = string.Join(", ", room.RemoteParticipants.Keys);
+                            Assert.Fail(
+                                $"Iteration {i}/{Iterations}: no agent participant within {AgentTimeoutSeconds}s. " +
+                                $"Room sid={room.Sid} name={room.Name} remoteParticipants=[{participants}]");
+                        }
+
+                        Debug.Log($"[AgentDispatchStress] Iteration {i}/{Iterations} OK (room sid={room.Sid} name={room.Name})");
+                    }
+                    finally
+                    {
+                        room.Disconnect();
+                    }
+                }
+            }
+            finally
+            {
+                LogAssert.ignoreFailingMessages = false;
+            }
+        }
+
+        static ITokenSourceConfigurable? CreateTokenSource()
+        {
+            if (Endpoint != null)
+                return new TokenSourceEndpoint(Endpoint, null);
+
+            if (SandBoxId != null)
+                return new TokenSourceSandbox(SandBoxId);
+
+            return null;
+        }
+
+        static string? ReadEnv(string key)
+        {
+            var value = Environment.GetEnvironmentVariable(key)?.Trim();
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+    }
+}

--- a/Tests/PlayMode/AgentDispatchStressTests.cs
+++ b/Tests/PlayMode/AgentDispatchStressTests.cs
@@ -18,10 +18,12 @@ namespace LiveKit.PlayModeTests
     /// The run stops at the first failure and logs the room sid/name so the failing room
     /// can be cross-checked against server-side dispatch logs.
     ///
-    /// The remote-participant check polls <c>Room.RemoteParticipants</c> rather than the
-    /// ParticipantConnected event so an agent delivered via the connect snapshot counts
-    /// the same as one delivered via an event — the bug under investigation is the
-    /// participant being absent from both.
+    /// Detection distinguishes the two delivery mechanisms: <c>Room.RemoteParticipants</c>
+    /// is checked exactly once after Connect returns (the snapshot path); afterwards only
+    /// the ParticipantConnected event can fulfill the expectation. On timeout the failure
+    /// message includes the remote-participant count at that moment — a count above zero
+    /// means the agent reached client state but its event never fired, zero means it never
+    /// reached the client at all.
     ///
     /// Gated by environment variables so CI (which runs no agent worker) skips it:
     ///   LK_TEST_AGENT_TOKEN_ENDPOINT — full token endpoint URL, or
@@ -31,6 +33,8 @@ namespace LiveKit.PlayModeTests
     {
         const int Iterations = 100;
         const float AgentTimeoutSeconds = 10f;
+        // The token service rate-limits room creation, so idle between iterations.
+        const float IterationCooldownSeconds = 5f;
         const int TestTimeoutMs = 30 * 60 * 1000;
 
         const string SandBoxId = null;
@@ -54,6 +58,9 @@ namespace LiveKit.PlayModeTests
             {
                 for (int i = 1; i <= Iterations; i++)
                 {
+                    if (i > 1)
+                        yield return new WaitForSecondsRealtime(IterationCooldownSeconds);
+
                     var fetch = new TaskYieldInstruction<ConnectionDetails>(
                         tokenSource.FetchConnectionDetails(new TokenSourceFetchOptions
                         {
@@ -69,6 +76,7 @@ namespace LiveKit.PlayModeTests
                         Assert.Fail($"Iteration {i}/{Iterations}: token source returned incomplete connection details");
 
                     var room = new Room();
+                    Room.ParticipantDelegate? onParticipantConnected = null;
                     try
                     {
                         var connect = room.Connect(fetch.Result.ServerUrl, fetch.Result.ParticipantToken, new RoomOptions());
@@ -76,23 +84,42 @@ namespace LiveKit.PlayModeTests
                         if (connect.IsError)
                             Assert.Fail($"Iteration {i}/{Iterations}: failed to connect");
 
-                        var agentAppeared = new Expectation(
-                            () => room.RemoteParticipants.Values.Any(p => p._info.Kind == Proto.ParticipantKind.Agent),
-                            timeoutSeconds: AgentTimeoutSeconds);
-                        yield return agentAppeared.Wait();
-
-                        if (agentAppeared.Error != null)
+                        var agentAppeared = new Expectation(timeoutSeconds: AgentTimeoutSeconds);
+                        onParticipantConnected = participant =>
                         {
-                            var participants = string.Join(", ", room.RemoteParticipants.Keys);
-                            Assert.Fail(
-                                $"Iteration {i}/{Iterations}: no agent participant within {AgentTimeoutSeconds}s. " +
-                                $"Room sid={room.Sid} name={room.Name} remoteParticipants=[{participants}]");
+                            if (participant._info.Kind == Proto.ParticipantKind.Agent)
+                                agentAppeared.Fulfill();
+                        };
+                        // Subscribe before the one-shot snapshot check; with no yield in
+                        // between, an agent can't slip through the gap. After this check
+                        // only the ParticipantConnected event can fulfill the expectation.
+                        room.ParticipantConnected += onParticipantConnected;
+
+                        string delivery;
+                        if (room.RemoteParticipants.Values.Any(p => p._info.Kind == Proto.ParticipantKind.Agent))
+                        {
+                            delivery = "snapshot";
+                        }
+                        else
+                        {
+                            yield return agentAppeared.Wait();
+                            if (agentAppeared.Error != null)
+                            {
+                                var remotes = room.RemoteParticipants;
+                                Assert.Fail(
+                                    $"Iteration {i}/{Iterations}: no ParticipantConnected for an agent within {AgentTimeoutSeconds}s. " +
+                                    $"Room sid={room.Sid} name={room.Name} remoteParticipantCount={remotes.Count} " +
+                                    $"remoteParticipants=[{string.Join(", ", remotes.Keys)}]");
+                            }
+                            delivery = "event";
                         }
 
-                        Debug.Log($"[AgentDispatchStress] Iteration {i}/{Iterations} OK (room sid={room.Sid} name={room.Name})");
+                        Debug.Log($"[AgentDispatchStress] Iteration {i}/{Iterations} OK (room sid={room.Sid} name={room.Name} delivery={delivery})");
                     }
                     finally
                     {
+                        if (onParticipantConnected != null)
+                            room.ParticipantConnected -= onParticipantConnected;
                         room.Disconnect();
                     }
                 }
@@ -112,12 +139,6 @@ namespace LiveKit.PlayModeTests
                 return new TokenSourceSandbox(SandBoxId);
 
             return null;
-        }
-
-        static string? ReadEnv(string key)
-        {
-            var value = Environment.GetEnvironmentVariable(key)?.Trim();
-            return string.IsNullOrEmpty(value) ? null : value;
         }
     }
 }

--- a/Tests/PlayMode/AgentDispatchStressTests.cs.meta
+++ b/Tests/PlayMode/AgentDispatchStressTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd5e840d11fd483d9318dd19bb2ebaa8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/ConcurrentJoinStressTests.cs
+++ b/Tests/PlayMode/ConcurrentJoinStressTests.cs
@@ -1,0 +1,140 @@
+using System.Collections;
+using LiveKit.PlayModeTests.Utils;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace LiveKit.PlayModeTests
+{
+    /// <summary>
+    /// Densely samples the join-handshake race that agent dispatch hits in production:
+    /// instead of a real agent, a second plain participant (the joiner) connects at a
+    /// controlled millisecond offset around the observer's connect, sweeping the
+    /// joiner's arrival across the observer's signal handshake — the window where a
+    /// remote participant's announcement is suspected to go missing.
+    ///
+    /// Detection follows the same pattern as <see cref="AgentDispatchStressTests"/>:
+    /// the observer's <c>Room.RemoteParticipants</c> is checked exactly once after the
+    /// connects complete; afterwards only the ParticipantConnected event can fulfill
+    /// the expectation. On timeout the failure message includes the sweep offset and
+    /// the remote-participant count at that moment.
+    ///
+    /// Local-only by design: requires a dev server (livekit-server --dev) and no agent
+    /// worker; enable by setting <see cref="Enabled"/> to true.
+    /// </summary>
+    public class ConcurrentJoinStressTests
+    {
+        static readonly bool Enabled = false;
+
+        const int Iterations = 100;
+        const float JoinTimeoutSeconds = 10f;
+        const int TestTimeoutMs = 30 * 60 * 1000;
+        // Sweep the joiner's connect offset relative to the observer's from
+        // -250ms (joiner first) to +245ms (observer first) in 5ms steps.
+        const int OffsetStartMs = -250;
+        const int OffsetStepMs = 5;
+
+        [UnityTest, Category("E2E"), Timeout(TestTimeoutMs)]
+        public IEnumerator ConcurrentJoin_ObserverSeesJoiner_100Iterations()
+        {
+            if (!Enabled)
+            {
+                Assert.Ignore(
+                    "Concurrent join test skipped: set Enabled = true to run it locally " +
+                    "(requires a dev server, e.g. livekit-server --dev).");
+                yield break;
+            }
+
+            LogAssert.ignoreFailingMessages = true;
+            try
+            {
+                for (int i = 1; i <= Iterations; i++)
+                {
+                    var offsetMs = OffsetStartMs + (i - 1) * OffsetStepMs;
+
+                    var observerOptions = TestRoomContext.ConnectionOptions.Default;
+                    observerOptions.Identity = "concurrent-observer";
+                    var joinerOptions = TestRoomContext.ConnectionOptions.Default;
+                    joinerOptions.Identity = "concurrent-joiner";
+
+                    using var context = new TestRoomContext(new[] { observerOptions, joinerOptions });
+                    var observer = context.Rooms[0];
+                    var joiner = context.Rooms[1];
+
+                    var joinerAppeared = new Expectation(timeoutSeconds: JoinTimeoutSeconds);
+                    Room.ParticipantDelegate onParticipantConnected = participant =>
+                    {
+                        if (participant.Identity == joinerOptions.Identity)
+                            joinerAppeared.Fulfill();
+                    };
+                    // Subscribed before Connect: frames elapse while both connects are in
+                    // flight, so a post-connect subscription could miss the event. The
+                    // snapshot check below still runs exactly once after the connects.
+                    observer.ParticipantConnected += onParticipantConnected;
+                    try
+                    {
+                        ConnectInstruction observerConnect, joinerConnect;
+                        if (offsetMs >= 0)
+                        {
+                            observerConnect = Connect(context, observer, observerOptions);
+                            if (offsetMs > 0)
+                                yield return new WaitForSecondsRealtime(offsetMs / 1000f);
+                            joinerConnect = Connect(context, joiner, joinerOptions);
+                        }
+                        else
+                        {
+                            joinerConnect = Connect(context, joiner, joinerOptions);
+                            yield return new WaitForSecondsRealtime(-offsetMs / 1000f);
+                            observerConnect = Connect(context, observer, observerOptions);
+                        }
+
+                        while (!observerConnect.IsDone || !joinerConnect.IsDone)
+                            yield return null;
+
+                        if (observerConnect.IsError || joinerConnect.IsError)
+                        {
+                            Assert.Fail(
+                                $"Iteration {i}/{Iterations} (offset {offsetMs}ms): connect failed " +
+                                $"(observer={(observerConnect.IsError ? "error" : "ok")}, " +
+                                $"joiner={(joinerConnect.IsError ? "error" : "ok")}) room={context.RoomName}");
+                        }
+
+                        string delivery;
+                        if (observer.RemoteParticipants.ContainsKey(joinerOptions.Identity))
+                        {
+                            delivery = "snapshot";
+                        }
+                        else
+                        {
+                            yield return joinerAppeared.Wait();
+                            if (joinerAppeared.Error != null)
+                            {
+                                var remotes = observer.RemoteParticipants;
+                                Assert.Fail(
+                                    $"Iteration {i}/{Iterations} (offset {offsetMs}ms): observer did not see " +
+                                    $"joiner within {JoinTimeoutSeconds}s. Room sid={observer.Sid} name={observer.Name} " +
+                                    $"remoteParticipantCount={remotes.Count} remoteParticipants=[{string.Join(", ", remotes.Keys)}]");
+                            }
+                            delivery = "event";
+                        }
+
+                        Debug.Log(
+                            $"[ConcurrentJoinStress] Iteration {i}/{Iterations} OK " +
+                            $"(offset={offsetMs}ms delivery={delivery} room={context.RoomName})");
+                    }
+                    finally
+                    {
+                        observer.ParticipantConnected -= onParticipantConnected;
+                    }
+                }
+            }
+            finally
+            {
+                LogAssert.ignoreFailingMessages = false;
+            }
+        }
+
+        static ConnectInstruction Connect(TestRoomContext context, Room room, TestRoomContext.ConnectionOptions options) =>
+            room.Connect(TestRoomContext.ServerUrl, context.CreateToken(options), new RoomOptions { Dynacast = options.Dynacast });
+    }
+}

--- a/Tests/PlayMode/ConcurrentJoinStressTests.cs.meta
+++ b/Tests/PlayMode/ConcurrentJoinStressTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0aeec5e9fbf445d687ade4ca1042c5f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/Utils/TestRoomContext.cs
+++ b/Tests/PlayMode/Utils/TestRoomContext.cs
@@ -87,7 +87,7 @@ namespace LiveKit.PlayModeTests.Utils
             Rooms.Clear();
         }
 
-        private string CreateToken(ConnectionOptions options)
+        internal string CreateToken(ConnectionOptions options)
         {
             var claims = new LiveKitToken.Claims
             {
@@ -121,6 +121,8 @@ namespace LiveKit.PlayModeTests.Utils
             if (disposing) DisconnectAll();
             _disposed = true;
         }
+
+        internal static string ServerUrl => _serverUrl;
 
         private static string _serverUrl => ReadEnv("LK_TEST_URL", "ws://localhost:7880");
         private static string _apiKey => ReadEnv("LK_TEST_API_KEY", "devkey");


### PR DESCRIPTION
## Summary

Automated reproduction for customer reports of dispatched agents missing from **both** the connect snapshot and the room events delivered after the `ReadyForRoomEvent` handshake (suspected pre-Join signal-message discard in the Rust SDK's `get_join_response`).

- New PlayMode test `AgentDispatchStressTests`: 100 iterations of fetch-token → connect → require a remote participant of kind `Agent` within 10s → disconnect.
- Polls `Room.RemoteParticipants` (not the `ParticipantConnected` event) so an agent delivered via the snapshot counts the same as one delivered via an event — the bug under investigation is the participant being absent from both.
- Exits at the first failure and logs the room sid/name so the failing room can be cross-checked against server-side dispatch logs.
- Token source comes from either an endpoint or sandbox id plus the agent name for dispatch.