### PR TITLE
Restore cached iOS audio session on PlatformAudio dispose

### DIFF
--- a/Runtime/Plugins/iOS/LiveKitAudioSession.mm
+++ b/Runtime/Plugins/iOS/LiveKitAudioSession.mm
@@ -16,6 +16,32 @@
 
 #import <AVFoundation/AVFoundation.h>
 
+// Snapshot of the AVAudioSession configuration as it was the first time LiveKit
+// touched the session (i.e. whatever Unity set up from its iOS Player Settings).
+// Captured lazily in LiveKit_ConfigureAudioSessionForVoIP and re-applied by
+// LiveKit_RestoreDefaultAudioSession when the last PlatformAudio is disposed.
+static BOOL s_hasCachedState = NO;
+static NSString* s_cachedCategory = nil;
+static NSString* s_cachedMode = nil;
+static AVAudioSessionCategoryOptions s_cachedCategoryOptions = 0;
+
+/// Captures the current audio session category/mode/options exactly once, before
+/// LiveKit reconfigures the session for VoIP. Subsequent calls are no-ops so the
+/// snapshot always reflects the pristine, pre-LiveKit (Unity-configured) state.
+static void LiveKit_CacheSessionStateIfNeeded() {
+    if (s_hasCachedState) {
+        return;
+    }
+    AVAudioSession* session = [AVAudioSession sharedInstance];
+    // copy so the strings persist for the app lifetime regardless of ARC/MRC.
+    s_cachedCategory = [session.category copy];
+    s_cachedMode = [session.mode copy];
+    s_cachedCategoryOptions = session.categoryOptions;
+    s_hasCachedState = YES;
+    NSLog(@"LiveKit: cached audio session state: category=%@, mode=%@, options=%lu",
+          s_cachedCategory, s_cachedMode, (unsigned long)s_cachedCategoryOptions);
+}
+
 extern "C" {
 
 /// Configures the iOS audio session for VoIP/WebRTC use.
@@ -28,6 +54,9 @@ extern "C" {
 /// Call this before creating PlatformAudio to ensure WebRTC can
 /// properly initialize the microphone and speaker.
 void LiveKit_ConfigureAudioSessionForVoIP() {
+    // Snapshot the pristine (Unity Player Settings) session before we change it.
+    LiveKit_CacheSessionStateIfNeeded();
+
     AVAudioSession* session = [AVAudioSession sharedInstance];
     NSError* error = nil;
 
@@ -54,16 +83,35 @@ void LiveKit_ConfigureAudioSessionForVoIP() {
     NSLog(@"LiveKit: Audio session configured for VoIP (PlayAndRecord + VoiceChat mode)");
 }
 
-/// Restores the audio session to the default ambient category.
-/// Call this when PlatformAudio is disposed if you want to restore
-/// the original audio behavior.
+/// Restores the audio session to the state cached before LiveKit first configured
+/// it for VoIP (see LiveKit_CacheSessionStateIfNeeded), and reactivates it so Unity
+/// audio plays normally again. Call this when the last PlatformAudio is disposed.
+/// Falls back to the ambient category if nothing was ever cached.
 void LiveKit_RestoreDefaultAudioSession() {
     AVAudioSession* session = [AVAudioSession sharedInstance];
     NSError* error = nil;
 
-    [session setCategory:AVAudioSessionCategoryAmbient error:&error];
-    if (error) {
-        NSLog(@"LiveKit: Failed to restore default audio session: %@", error.localizedDescription);
+    if (s_hasCachedState) {
+        if (![session setCategory:s_cachedCategory
+                             mode:s_cachedMode
+                          options:s_cachedCategoryOptions
+                            error:&error] || error) {
+            NSLog(@"LiveKit: Failed to restore cached audio session (category=%@, mode=%@): %@",
+                  s_cachedCategory, s_cachedMode, error.localizedDescription);
+        }
+    } else {
+        // Configure was never called, so we have nothing to restore to; fall back
+        // to the ambient category.
+        [session setCategory:AVAudioSessionCategoryAmbient error:&error];
+        if (error) {
+            NSLog(@"LiveKit: Failed to restore default audio session: %@", error.localizedDescription);
+        }
+    }
+
+    // Hand an active session back to Unity so its audio output resumes.
+    error = nil;
+    if (![session setActive:YES error:&error] || error) {
+        NSLog(@"LiveKit: Failed to reactivate audio session: %@", error.localizedDescription);
     }
 }
 

--- a/Runtime/Scripts/Audio/PlatformAudio.cs
+++ b/Runtime/Scripts/Audio/PlatformAudio.cs
@@ -74,6 +74,11 @@ namespace LiveKit
         internal readonly FfiHandle Handle;
         private readonly PlatformAudioInfo _info;
         private bool _disposed = false;
+#if UNITY_IOS && !UNITY_EDITOR
+        // Tracks live PlatformAudio instances so the iOS audio session is restored
+        // only when the last one is disposed (aligned with the native ADM ref-count).
+        private static int _instanceCount;
+#endif
 
         /// <summary>
         /// Number of available recording (microphone) devices.
@@ -119,6 +124,12 @@ namespace LiveKit
             _info = platformAudio.Info;
 
             Utils.Debug($"PlatformAudio created: {RecordingDeviceCount} recording devices, {PlayoutDeviceCount} playout devices");
+
+#if UNITY_IOS && !UNITY_EDITOR
+            // Count this instance only after successful construction so a failed
+            // ctor never leaves the counter stuck above zero.
+            System.Threading.Interlocked.Increment(ref _instanceCount);
+#endif
         }
 
         /// <summary>
@@ -365,6 +376,14 @@ namespace LiveKit
             if (_disposed) return;
             Handle.Dispose();
             _disposed = true;
+
+#if UNITY_IOS && !UNITY_EDITOR
+            // Restore the audio session Unity had before VoIP, but only once the
+            // last PlatformAudio is gone (the native ADM is likewise ref-counted).
+            if (System.Threading.Interlocked.Decrement(ref _instanceCount) == 0)
+                IOSAudioSessionHelper.LiveKit_RestoreDefaultAudioSession();
+#endif
+
             Utils.Debug("PlatformAudio disposed");
         }
     }


### PR DESCRIPTION
## Problem

On iOS, constructing `PlatformAudio` calls `LiveKit_ConfigureAudioSessionForVoIP()`, switching the shared `AVAudioSession` to `PlayAndRecord` + `VoiceChat`. On dispose, nothing restored it:

- `PlatformAudio.Dispose()` never called the restore hook — `LiveKit_RestoreDefaultAudioSession()` was **dead code** (declared + implemented, zero callers).
- Even if called, it hardcoded `AVAudioSessionCategoryAmbient` and never reactivated.

Net effect: after a call ended, the app's session stayed on the VoIP profile and deactivated, so normal Unity audio playback was degraded (quiet, receiver-biased routing). `AudioSettings.Reset` does not fix this — it only reinitializes Unity's internal (FMOD) engine, not the OS-level session.

## Change

- **`LiveKitAudioSession.mm`**: snapshot `category`/`mode`/`categoryOptions` once, lazily, at the top of `LiveKit_ConfigureAudioSessionForVoIP()` — i.e. right before LiveKit first mutates the session, so it captures whatever Unity configured from its iOS Player Settings. Rewrite `LiveKit_RestoreDefaultAudioSession()` to re-apply that snapshot and `setActive:YES` (falls back to `Ambient` only if nothing was cached).
- **`PlatformAudio.cs`**: track live instances with an `Interlocked` counter (iOS-guarded); increment after successful construction, decrement in `Dispose()`, and fire restore only when the count hits 0 — matching the native ADM ref-count teardown.

Explicit-`Dispose()` only (no finalizer): avoids touching `AVAudioSession` off the main thread. Kept minimal — the existing automatic-mode / `VoiceChat` config is unchanged.

## Testing

- C# Runtime assembly compiles cleanly with `UNITY_IOS` defined / `UNITY_EDITOR` off (0 errors) — the guarded code is actually type-checked.
- `.mm` passes `clang -fsyntax-only` against the iOS SDK under both ARC and MRC (no errors).
- **Needs on-device verification** (not doable in CI): connect a room with `PlatformAudio`, dispose it, then play a Unity `AudioSource` and confirm routing/volume return to the pre-call behavior. The new `NSLog`s report the cached + restored category/mode.

## Follow-ups (out of scope)

- A more advanced manual-mode prototype (RTCAudioSession `useManualAudio`, `VideoChat`, VPIO gating to keep Unity audio alive *during* calls) exists as a build artifact under `Samples~/Meet/Builds/` — not adopted here.
- `.mm.meta` also targets visionOS/tvOS, but the C# P/Invoke is `UNITY_IOS`-only (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)