### PR TITLE
Adding automatic signing for iOS

### DIFF
--- a/Samples~/Meet/Assets/Editor/BuildPostProcessor.cs
+++ b/Samples~/Meet/Assets/Editor/BuildPostProcessor.cs
@@ -26,7 +26,37 @@ public class BuildPostProcessor
         string fileGuid = proj.FindFileGuidByProjectPath("Libraries/libiPhone-lib.a");
         proj.RemoveFileFromBuild(guid, fileGuid);
         proj.AddFileToBuild(guid, fileGuid);
+
+        ApplyAutomaticSigning(proj);
+
         proj.WriteToFile(projPath);
+    }
+
+    private static void ApplyAutomaticSigning(PBXProject proj)
+    {
+        // Team ID lives in EditorPrefs (per-machine, never committed); set it under
+        // Edit > Preferences > iOS Signing. Skip signing entirely when it is unset,
+        // which leaves a Replace build's signing for you to fill in manually.
+        var teamId = EditorPrefs.GetString(IosSigningPreferences.TeamIdKey, string.Empty);
+        if (string.IsNullOrEmpty(teamId))
+            return;
+
+        // Sign both the app target and the embedded UnityFramework target.
+#if UNITY_2019_3_OR_NEWER
+        string[] targets = { proj.GetUnityMainTargetGuid(), proj.GetUnityFrameworkTargetGuid() };
+#else
+        string[] targets = { proj.TargetGuidByName("Unity-iPhone") };
+#endif
+        foreach (var target in targets)
+        {
+            proj.SetBuildProperty(target, "CODE_SIGN_STYLE", "Automatic");
+            proj.SetBuildProperty(target, "DEVELOPMENT_TEAM", teamId);
+            // Automatic signing manages the profile itself; a leftover manual
+            // specifier would conflict and re-introduce the signing prompt.
+            proj.SetBuildProperty(target, "PROVISIONING_PROFILE_SPECIFIER", "");
+        }
+
+        Debug.Log($"iOS automatic signing applied with team {teamId}.");
     }
 }
 

--- a/Samples~/Meet/Assets/Editor/IosSigningPreferences.cs
+++ b/Samples~/Meet/Assets/Editor/IosSigningPreferences.cs
@@ -1,0 +1,38 @@
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// User-scoped Preferences entry (Edit > Preferences > iOS Signing) for the Apple
+/// Team ID used to auto-sign iOS builds. The value is kept in EditorPrefs, which is
+/// per-user and per-machine and never part of the repo — so there is nothing to
+/// gitignore — and the build post-processor can read it without an environment
+/// variable or launching the Editor from a console.
+/// </summary>
+public static class IosSigningPreferences
+{
+    public const string TeamIdKey = "iOS.TeamID";
+
+    [SettingsProvider]
+    public static SettingsProvider CreateProvider()
+    {
+        return new SettingsProvider("Preferences/iOS Signing", SettingsScope.User)
+        {
+            label = "iOS Signing",
+            guiHandler = _ =>
+            {
+                EditorGUILayout.HelpBox(
+                    "Apple Team ID used to auto-sign iOS builds. Stored locally in EditorPrefs " +
+                    "(per-machine, never committed) and applied on every build. Leave empty to " +
+                    "sign manually in Xcode.",
+                    MessageType.Info);
+
+                var current = EditorPrefs.GetString(TeamIdKey, string.Empty);
+                EditorGUI.BeginChangeCheck();
+                var updated = EditorGUILayout.TextField("Team ID", current);
+                if (EditorGUI.EndChangeCheck())
+                    EditorPrefs.SetString(TeamIdKey, updated.Trim());
+            },
+            keywords = new[] { "iOS", "Team", "Signing", "Apple", "Team ID", "Xcode" }
+        };
+    }
+}

--- a/Samples~/Meet/Assets/Editor/IosSigningPreferences.cs.meta
+++ b/Samples~/Meet/Assets/Editor/IosSigningPreferences.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b1642cd5ba72455ebdb5a6e74e6d38b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Background

When building for iOS, we have to replace instead of append due to our post build script. I then have to add signing information manually every time. This adds a build helper where I can place my apple team id and it signs in Xcode.

### Changes

What did you do?

- Adds field for apple id under Unity > Settings > iOS Signing
- Applies automatic signing to generated Xcode project if id is set