### PR TITLE
Harden build_ffi_locally.sh so iOS/Android cross builds use rustup

### DIFF
--- a/Scripts~/build_ffi_locally.sh
+++ b/Scripts~/build_ffi_locally.sh
@@ -11,6 +11,14 @@ YELLOW='\033[0;33m'
 GREEN='\033[0;32m'
 RESET='\033[0m'
 
+# Prefer rustup-managed toolchains over any other rust in PATH (e.g. a Homebrew
+# rust in /opt/homebrew/bin). The wrong rustc ignores rust-toolchain.toml and
+# ships only its host target, so cross builds fail with "can't find crate for std".
+CARGO_BIN="${CARGO_HOME:-$HOME/.cargo}/bin"
+if [ -x "$CARGO_BIN/rustup" ]; then
+    export PATH="$CARGO_BIN:$PATH"
+fi
+
 usage() {
     echo "Usage: $0 <platform> [build_type]"
     echo ""
@@ -52,12 +60,15 @@ case "$PLATFORM" in
     # MACOS
     macos)
         echo "Building for macOS (aarch64-apple-darwin) [$BUILD_TYPE]..."
+        pushd "$ROOT/client-sdk-rust~" > /dev/null
+        rustup target add aarch64-apple-darwin
         cargo build \
             --manifest-path "$MANIFEST" \
             $BUILD_FLAG \
             -p livekit-ffi \
             --target aarch64-apple-darwin
         BUILD_STATUS=$?
+        popd > /dev/null
 
         SRC="$BASE_TARGET/aarch64-apple-darwin/$BUILD_DIR/liblivekit_ffi.dylib"
         DST="$BASE_DST/ffi-macos-arm64/liblivekit_ffi.dylib"
@@ -66,6 +77,7 @@ case "$PLATFORM" in
     android)
         echo "Building for Android (aarch64-linux-android) [$BUILD_TYPE]..."
         pushd "$ROOT/client-sdk-rust~" > /dev/null
+        rustup target add aarch64-linux-android
         cargo ndk \
             --target aarch64-linux-android \
             build \
@@ -86,6 +98,7 @@ case "$PLATFORM" in
     ios)
         echo "Building for iOS (aarch64-apple-ios) [$BUILD_TYPE]..."
         pushd "$ROOT/client-sdk-rust~/livekit-ffi" > /dev/null
+        rustup target add aarch64-apple-ios
         cargo rustc \
             --crate-type staticlib \
             $BUILD_FLAG \


### PR DESCRIPTION
### Background

Rebuilding the FFI libs locally with `Scripts~/build_ffi_locally.sh` started failing for **iOS** and **Android** with `error[E0463]: can't find crate for core / std` — the cross-compilation targets appeared not installed.

Two compounding causes:

1. **Wrong rustc.** A Homebrew rust in `/opt/homebrew/bin` precedes `~/.cargo/bin` in `PATH`, so `cargo`/`rustc` resolve to Homebrew's toolchain. That toolchain ignores `rust-toolchain.toml` and ships only its host target (`aarch64-apple-darwin`), so cross builds can't find the target's `std`/`core`. macOS kept working only because its target *is* Homebrew rust's host.
2. **Pinned toolchain not equipped.** `client-sdk-rust~/rust-toolchain.toml` pins channel `1.96.1` (picked up because the iOS/Android steps `cd` into the submodule), but the iOS/Android target std libs were only ever added to a different toolchain — `1.96.1` had `aarch64-apple-darwin` only.

### Changes

Harden `Scripts~/build_ffi_locally.sh` (dev-only script, not shipped in the package):

- Prepend `${CARGO_HOME:-$HOME/.cargo}/bin` to `PATH` (when rustup is present) so rustup-managed toolchains always win over a stray Homebrew/system rust and `rust-toolchain.toml` is honored.
- Run `rustup target add <target>` before each build (idempotent — instant if already present) so the pinned toolchain is self-equipping.
- Route the macOS build through the submodule dir too, so all three platforms consistently build with the pinned toolchain.

Verified: `Scripts~/build_ffi_locally.sh ios debug` now completes and copies a fresh `arm64` `liblivekit_ffi.a`. Rebuilt binaries are intentionally **not** included — this PR is scoped to the script change only.