### PR TITLE
Fix set null to empty in proto

### DIFF
--- a/Runtime/Scripts/DataStreams/ByteDataStream.cs
+++ b/Runtime/Scripts/DataStreams/ByteDataStream.cs
@@ -112,8 +112,8 @@ namespace LiveKit
             using var request = FFIBridge.Instance.NewRequest<ByteStreamReaderWriteToFileRequest>();
             var writeToFileReq = request.request;
             writeToFileReq.ReaderHandle = (ulong)_handle.DangerousGetHandle();
-            writeToFileReq.Directory = directory;
-            writeToFileReq.NameOverride = nameOverride;
+            if (directory != null) writeToFileReq.Directory = directory;
+            if (nameOverride != null) writeToFileReq.NameOverride = nameOverride;
 
             var instruction = new WriteToFileInstruction(request.RequestAsyncId);
             using var response = request.Send();


### PR DESCRIPTION
### Background

We were setting the fields to null explicitly which is not allowed in protos, just leave empty for null