### PR TITLE
Fix bug in EOS for data streams

### DIFF
--- a/Runtime/Scripts/DataStreams/ByteDataStream.cs
+++ b/Runtime/Scripts/DataStreams/ByteDataStream.cs
@@ -145,8 +145,9 @@ namespace LiveKit
         /// YieldInstruction for <see cref="ReadIncremental"/>.
         /// </summary>
         /// <remarks>
-        /// Usage: while <see cref="IsEos"/> is false (i.e. the stream has not ended),
-        /// call <see cref="Reset"/>, yield the instruction, and then access <see cref="Bytes"/>.
+        /// Usage: loop yielding the instruction; when it resumes, break if <see cref="IsEos"/>
+        /// is true (the stream has ended and every chunk has been drained), otherwise read
+        /// <see cref="Bytes"/> and call <see cref="Reset"/> to advance to the next chunk.
         /// </remarks>
         public sealed class ReadIncrementalInstruction : ReadIncrementalInstructionBase<byte[]>
         {

--- a/Runtime/Scripts/DataStreams/DataStream.cs
+++ b/Runtime/Scripts/DataStreams/DataStream.cs
@@ -85,6 +85,8 @@ namespace LiveKit
 
         // A chunk or the terminal end-of-stream marker. Chunks and the marker share one
         // FIFO so the consumer can never observe end-of-stream while chunks remain buffered.
+        // The head of the queue is the item the consumer is currently positioned on; Reset()
+        // dequeues it to advance to the next.
         private readonly struct Item
         {
             public readonly TContent Chunk;
@@ -102,14 +104,11 @@ namespace LiveKit
             public static Item ForTerminal(StreamError error) => new Item(default, true, error);
         }
 
-        // Items buffered beyond the one the consumer is currently positioned on.
         private readonly Queue<Item> _queue = new();
-        private Item _current;
-        private bool _hasCurrent;
 
         // Chunk/EOS events arrive on the FFI thread; Reset() and the LatestChunk getter run on
-        // the main-thread coroutine. _gate serializes mutations of the queue, the current item,
-        // IsCurrentReadDone, IsEos, and Error across both sides.
+        // the main-thread coroutine. _gate serializes mutations of the queue, IsCurrentReadDone,
+        // IsEos, and Error across both sides.
         private readonly object _gate = new();
 
         /// <summary>
@@ -137,8 +136,7 @@ namespace LiveKit
                 lock (_gate)
                 {
                     if (Error != null) throw Error;
-                    if (!_hasCurrent) return default;
-                    return _current.Chunk;
+                    return _queue.Count > 0 ? _queue.Peek().Chunk : default;
                 }
             }
         }
@@ -150,75 +148,51 @@ namespace LiveKit
 
         protected bool MatchesHandle(ulong eventHandle) => eventHandle == _handleValue;
 
-        protected void OnChunk(TContent content)
+        protected void OnChunk(TContent content) => Enqueue(Item.ForChunk(content));
+
+        protected void OnEos(Proto.StreamError protoError) =>
+            Enqueue(Item.ForTerminal(protoError != null ? new StreamError(protoError) : null));
+
+        private void Enqueue(Item item)
         {
             lock (_gate)
             {
-                if (_hasCurrent)
-                {
-                    // Consumer hasn't advanced onto the current item yet; buffer in order.
-                    _queue.Enqueue(Item.ForChunk(content));
-                }
-                else
-                {
-                    Advance(Item.ForChunk(content));
-                }
+                // When the queue was empty this item becomes the head, so publish it now;
+                // otherwise it stays buffered in order behind the current head.
+                bool wasEmpty = _queue.Count == 0;
+                _queue.Enqueue(item);
+                if (wasEmpty) SettleHead();
             }
         }
 
         public override void Reset()
         {
-            // base.Reset() must run under the same lock as OnChunk/OnEos, otherwise the
-            // window between IsCurrentReadDone=false (from base) and the dequeue below lets
-            // a producer race in, position the current item, and have it immediately
-            // overwritten by the dequeue. base.Reset() also throws when the consumer tries to
-            // advance past the terminal marker (IsEos), which is the intended guard.
+            // base.Reset() must run under the same lock as OnChunk/OnEos so a producer can't
+            // race between the flag clear and the dequeue below. It also throws when the
+            // consumer tries to advance past the terminal marker (IsEos), the intended guard.
             lock (_gate)
             {
                 base.Reset();
-                if (_queue.Count > 0)
-                {
-                    Advance(_queue.Dequeue());
-                }
-                else
-                {
-                    // Nothing buffered: park until the next chunk or the terminal marker
-                    // arrives. keepWaiting stays true until then.
-                    _hasCurrent = false;
-                }
+                if (_queue.Count > 0) _queue.Dequeue(); // drop the item just consumed
+                SettleHead();
             }
         }
 
-        protected void OnEos(Proto.StreamError protoError)
-        {
-            lock (_gate)
-            {
-                var error = protoError != null ? new StreamError(protoError) : null;
-                if (_hasCurrent)
-                {
-                    // Ordered after every buffered chunk; the consumer drains them first.
-                    _queue.Enqueue(Item.ForTerminal(error));
-                }
-                else
-                {
-                    Advance(Item.ForTerminal(error));
-                }
-            }
-        }
-
-        // Positions the consumer on the given item and flips the matching completion flag.
+        // Reflects the queue head in the base completion flags: a chunk becomes readable
+        // (IsCurrentReadDone), the terminal marker ends the stream (IsEos). An empty queue
+        // parks the consumer (keepWaiting stays true) until the next item arrives.
         // Caller must hold _gate.
-        private void Advance(Item item)
+        private void SettleHead()
         {
-            _current = item;
-            _hasCurrent = true;
-            if (item.IsTerminal)
+            if (_queue.Count == 0) return;
+            var head = _queue.Peek();
+            if (head.IsTerminal)
             {
                 // Assign Error before flipping IsEos. The IsEos setter fires the awaiter
                 // continuation, which inspects IsError/Error on resume; setting IsEos first
                 // would let the continuation observe IsError == false and silently swallow
                 // the stream error.
-                if (item.Error != null) Error = item.Error;
+                if (head.Error != null) Error = head.Error;
                 IsEos = true;
             }
             else

--- a/Runtime/Scripts/DataStreams/DataStream.cs
+++ b/Runtime/Scripts/DataStreams/DataStream.cs
@@ -73,7 +73,7 @@ namespace LiveKit
     /// <summary>
     /// Shared state and helpers for incremental stream reader yield instructions.
     /// Models the incoming stream as a single ordered queue whose items are either a
-    /// chunk or a terminal end-of-stream marker (carrying an optional <see cref="StreamError"/>).
+    /// chunk or a the end-of-stream marker (carrying an optional <see cref="StreamError"/>).
     /// The consumer advances through the queue one item at a time via <see cref="Reset"/>;
     /// end-of-stream is only observed once every buffered chunk has been drained, mirroring
     /// the JS and Python SDKs. Subclasses own the typed event subscription and convert raw
@@ -83,25 +83,25 @@ namespace LiveKit
     {
         private readonly ulong _handleValue;
 
-        // A chunk or the terminal end-of-stream marker. Chunks and the marker share one
+        // A chunk or the end-of-stream marker. Chunks and the marker share one
         // FIFO so the consumer can never observe end-of-stream while chunks remain buffered.
         // The head of the queue is the item the consumer is currently positioned on; Reset()
         // dequeues it to advance to the next.
         private readonly struct Item
         {
             public readonly TContent Chunk;
-            public readonly bool IsTerminal;
+            public readonly bool IsEos;
             public readonly StreamError Error;
 
-            private Item(TContent chunk, bool isTerminal, StreamError error)
+            private Item(TContent chunk, bool isEos, StreamError error)
             {
                 Chunk = chunk;
-                IsTerminal = isTerminal;
+                IsEos = isEos;
                 Error = error;
             }
 
             public static Item ForChunk(TContent chunk) => new Item(chunk, false, null);
-            public static Item ForTerminal(StreamError error) => new Item(default, true, error);
+            public static Item ForEos(StreamError error) => new Item(default, true, error);
         }
 
         private readonly Queue<Item> _queue = new();
@@ -151,7 +151,7 @@ namespace LiveKit
         protected void OnChunk(TContent content) => Enqueue(Item.ForChunk(content));
 
         protected void OnEos(Proto.StreamError protoError) =>
-            Enqueue(Item.ForTerminal(protoError != null ? new StreamError(protoError) : null));
+            Enqueue(Item.ForEos(protoError != null ? new StreamError(protoError) : null));
 
         private void Enqueue(Item item)
         {
@@ -169,7 +169,7 @@ namespace LiveKit
         {
             // base.Reset() must run under the same lock as OnChunk/OnEos so a producer can't
             // race between the flag clear and the dequeue below. It also throws when the
-            // consumer tries to advance past the terminal marker (IsEos), the intended guard.
+            // consumer tries to advance past the Eos marker (IsEos), the intended guard.
             lock (_gate)
             {
                 base.Reset();
@@ -179,14 +179,14 @@ namespace LiveKit
         }
 
         // Reflects the queue head in the base completion flags: a chunk becomes readable
-        // (IsCurrentReadDone), the terminal marker ends the stream (IsEos). An empty queue
+        // (IsCurrentReadDone), the Eos marker (IsEos) ends the stream. An empty queue
         // parks the consumer (keepWaiting stays true) until the next item arrives.
         // Caller must hold _gate.
         private void SettleHead()
         {
             if (_queue.Count == 0) return;
             var head = _queue.Peek();
-            if (head.IsTerminal)
+            if (head.IsEos)
             {
                 // Assign Error before flipping IsEos. The IsEos setter fires the awaiter
                 // continuation, which inspects IsError/Error on resume; setting IsEos first

--- a/Runtime/Scripts/DataStreams/DataStream.cs
+++ b/Runtime/Scripts/DataStreams/DataStream.cs
@@ -72,19 +72,44 @@ namespace LiveKit
 
     /// <summary>
     /// Shared state and helpers for incremental stream reader yield instructions.
-    /// Holds the latest chunk, end-of-stream flag, and error; subclasses own the
-    /// typed event subscription and convert raw event payloads via <see cref="OnChunk"/>
-    /// and <see cref="OnEos"/>.
+    /// Models the incoming stream as a single ordered queue whose items are either a
+    /// chunk or a terminal end-of-stream marker (carrying an optional <see cref="StreamError"/>).
+    /// The consumer advances through the queue one item at a time via <see cref="Reset"/>;
+    /// end-of-stream is only observed once every buffered chunk has been drained, mirroring
+    /// the JS and Python SDKs. Subclasses own the typed event subscription and convert raw
+    /// event payloads via <see cref="OnChunk"/> and <see cref="OnEos"/>.
     /// </summary>
     public abstract class ReadIncrementalInstructionBase<TContent> : StreamYieldInstruction
     {
         private readonly ulong _handleValue;
-        private readonly Queue<TContent> _pendingChunks = new();
-        private TContent _latestChunk;
 
-        // Chunk events arrive on the FFI thread; Reset() and the LatestChunk getter
-        // run on the main-thread coroutine. _gate serializes mutations of the queue,
-        // _latestChunk, IsCurrentReadDone, IsEos, and Error across both sides.
+        // A chunk or the terminal end-of-stream marker. Chunks and the marker share one
+        // FIFO so the consumer can never observe end-of-stream while chunks remain buffered.
+        private readonly struct Item
+        {
+            public readonly TContent Chunk;
+            public readonly bool IsTerminal;
+            public readonly StreamError Error;
+
+            private Item(TContent chunk, bool isTerminal, StreamError error)
+            {
+                Chunk = chunk;
+                IsTerminal = isTerminal;
+                Error = error;
+            }
+
+            public static Item ForChunk(TContent chunk) => new Item(chunk, false, null);
+            public static Item ForTerminal(StreamError error) => new Item(default, true, error);
+        }
+
+        // Items buffered beyond the one the consumer is currently positioned on.
+        private readonly Queue<Item> _queue = new();
+        private Item _current;
+        private bool _hasCurrent;
+
+        // Chunk/EOS events arrive on the FFI thread; Reset() and the LatestChunk getter run on
+        // the main-thread coroutine. _gate serializes mutations of the queue, the current item,
+        // IsCurrentReadDone, IsEos, and Error across both sides.
         private readonly object _gate = new();
 
         /// <summary>
@@ -99,10 +124,11 @@ namespace LiveKit
 
         /// <summary>
         /// The chunk from the most recent completed read. Throws the captured
-        /// <see cref="StreamError"/> if the last read errored. Internal so the optional
-        /// UniTask async-enumerable adapter (which has InternalsVisibleTo access) can read
-        /// it generically; the typed <c>Bytes</c>/<c>Text</c> accessors on the concrete
-        /// readers delegate here.
+        /// <see cref="StreamError"/> if the stream ended with an error. Returns the default
+        /// value once positioned on a normal end-of-stream marker (there is no chunk to read).
+        /// Internal so the optional UniTask async-enumerable adapter (which has
+        /// InternalsVisibleTo access) can read it generically; the typed <c>Bytes</c>/<c>Text</c>
+        /// accessors on the concrete readers delegate here.
         /// </summary>
         internal TContent LatestChunk
         {
@@ -111,7 +137,8 @@ namespace LiveKit
                 lock (_gate)
                 {
                     if (Error != null) throw Error;
-                    return _latestChunk;
+                    if (!_hasCurrent) return default;
+                    return _current.Chunk;
                 }
             }
         }
@@ -127,33 +154,37 @@ namespace LiveKit
         {
             lock (_gate)
             {
-                if (IsCurrentReadDone)
+                if (_hasCurrent)
                 {
-                    // Consumer hasn't yielded since the last chunk; buffer until Reset().
-                    _pendingChunks.Enqueue(content);
+                    // Consumer hasn't advanced onto the current item yet; buffer in order.
+                    _queue.Enqueue(Item.ForChunk(content));
                 }
                 else
                 {
-                    _latestChunk = content;
-                    IsCurrentReadDone = true;
+                    Advance(Item.ForChunk(content));
                 }
             }
         }
 
         public override void Reset()
         {
-            // base.Reset() must run under the same lock as OnChunk, otherwise the
-            // window between IsCurrentReadDone=false (from base) and the dequeue
-            // below lets a producer race in, write _latestChunk, and have its
-            // chunk immediately overwritten by the dequeue. That race lost ~4% of
-            // chunks under stress before this fix.
+            // base.Reset() must run under the same lock as OnChunk/OnEos, otherwise the
+            // window between IsCurrentReadDone=false (from base) and the dequeue below lets
+            // a producer race in, position the current item, and have it immediately
+            // overwritten by the dequeue. base.Reset() also throws when the consumer tries to
+            // advance past the terminal marker (IsEos), which is the intended guard.
             lock (_gate)
             {
                 base.Reset();
-                if (_pendingChunks.Count > 0)
+                if (_queue.Count > 0)
                 {
-                    _latestChunk = _pendingChunks.Dequeue();
-                    IsCurrentReadDone = true;
+                    Advance(_queue.Dequeue());
+                }
+                else
+                {
+                    // Nothing buffered: park until the next chunk or the terminal marker
+                    // arrives. keepWaiting stays true until then.
+                    _hasCurrent = false;
                 }
             }
         }
@@ -162,15 +193,37 @@ namespace LiveKit
         {
             lock (_gate)
             {
-                // Assign Error before flipping IsEos. The IsEos setter fires the awaiter
-                // continuation, which inspects IsError/Error on resume; when completion runs
-                // inline on the main thread, setting IsEos first would let the continuation
-                // observe IsError == false and silently swallow the stream error.
-                if (protoError != null)
+                var error = protoError != null ? new StreamError(protoError) : null;
+                if (_hasCurrent)
                 {
-                    Error = new StreamError(protoError);
+                    // Ordered after every buffered chunk; the consumer drains them first.
+                    _queue.Enqueue(Item.ForTerminal(error));
                 }
+                else
+                {
+                    Advance(Item.ForTerminal(error));
+                }
+            }
+        }
+
+        // Positions the consumer on the given item and flips the matching completion flag.
+        // Caller must hold _gate.
+        private void Advance(Item item)
+        {
+            _current = item;
+            _hasCurrent = true;
+            if (item.IsTerminal)
+            {
+                // Assign Error before flipping IsEos. The IsEos setter fires the awaiter
+                // continuation, which inspects IsError/Error on resume; setting IsEos first
+                // would let the continuation observe IsError == false and silently swallow
+                // the stream error.
+                if (item.Error != null) Error = item.Error;
                 IsEos = true;
+            }
+            else
+            {
+                IsCurrentReadDone = true;
             }
         }
     }

--- a/Runtime/Scripts/DataStreams/TextDataStream.cs
+++ b/Runtime/Scripts/DataStreams/TextDataStream.cs
@@ -136,8 +136,9 @@ namespace LiveKit
         /// YieldInstruction for <see cref="ReadIncremental"/>.
         /// </summary>
         /// <remarks>
-        /// Usage: while <see cref="IsEos"/> is false (i.e. the stream has not ended),
-        /// call <see cref="Reset"/>, yield the instruction, and then access <see cref="Text"/>.
+        /// Usage: loop yielding the instruction; when it resumes, break if <see cref="IsEos"/>
+        /// is true (the stream has ended and every chunk has been drained), otherwise read
+        /// <see cref="Text"/> and call <see cref="Reset"/> to advance to the next chunk.
         /// </remarks>
         public sealed class ReadIncrementalInstruction : ReadIncrementalInstructionBase<string>
         {

--- a/Runtime/Scripts/UniTask/StreamReaderUniTaskExtensions.cs
+++ b/Runtime/Scripts/UniTask/StreamReaderUniTaskExtensions.cs
@@ -18,17 +18,13 @@ namespace LiveKit
         /// <see cref="TextStreamReader.ReadIncrementalInstruction"/> (<c>string</c>).
         /// </summary>
         /// <remarks>
-        /// Iteration ends when the stream reaches end-of-stream. If the stream ends with an
-        /// error, the enumerable throws that <see cref="StreamError"/> (idiomatic for
-        /// <c>await foreach</c>; this is the one place the UniTask surface throws rather than
-        /// exposing <c>IsError</c>). Cancellation (via the token or the enumerator) surfaces as
-        /// <see cref="System.OperationCanceledException"/> with abandon-awaiter semantics — the
-        /// underlying FFI read is not cancelled on the wire.
-        ///
-        /// The current chunk is delivered on the iteration where end-of-stream is also observed,
-        /// then iteration stops. Chunks buffered <em>beyond</em> the current one when
-        /// end-of-stream arrives are not drainable, because the reader disallows <c>Reset()</c>
-        /// past end-of-stream.
+        /// Iteration ends when the stream reaches end-of-stream. Every buffered chunk is
+        /// drained before iteration stops, since end-of-stream is an ordered item at the tail
+        /// of the chunk queue. If the stream ends with an error, the enumerable throws that
+        /// <see cref="StreamError"/> (idiomatic for <c>await foreach</c>; this is the one place
+        /// the UniTask surface throws rather than exposing <c>IsError</c>). Cancellation (via
+        /// the token or the enumerator) surfaces as <see cref="System.OperationCanceledException"/>
+        /// with abandon-awaiter semantics — the underlying FFI read is not cancelled on the wire.
         /// </remarks>
         public static IUniTaskAsyncEnumerable<TChunk> AsAsyncEnumerable<TChunk>(
             this ReadIncrementalInstructionBase<TChunk> instruction,
@@ -44,30 +40,20 @@ namespace LiveKit
 
                 while (true)
                 {
-                    // Completes when a chunk is ready (IsCurrentReadDone) or the stream ends (IsEos).
+                    // Completes when a chunk is ready (IsCurrentReadDone) or the consumer has
+                    // advanced onto the terminal marker (IsEos) — the two are mutually exclusive.
                     await instruction.AsUniTask(ct);
 
                     if (instruction.IsCurrentReadDone)
                     {
                         var chunk = instruction.LatestChunk;
                         await writer.YieldAsync(chunk);
-
-                        // Re-check IsEos AFTER yielding: end-of-stream may have arrived while
-                        // the consumer was suspended. Reset() throws once IsEos is set, so this
-                        // re-check (not a value captured before the yield) is what keeps the
-                        // loop safe — mirroring the coroutine consumer's "if (IsEos) break;
-                        // else Reset()" ordering.
-                        if (instruction.IsEos)
-                        {
-                            if (instruction.IsError) throw instruction.Error;
-                            return;
-                        }
-
-                        instruction.Reset();
+                        instruction.Reset(); // advance to the next chunk or the terminal marker
                         continue;
                     }
 
-                    // Not IsCurrentReadDone => end-of-stream with nothing left to read.
+                    // Positioned on the terminal marker: the queue is fully drained. Surface an
+                    // error close by throwing, otherwise end iteration cleanly.
                     if (instruction.IsError) throw instruction.Error;
                     return;
                 }

--- a/Samples~/Agents/Assets/Runtime/Agent/TranscriptionReader.cs
+++ b/Samples~/Agents/Assets/Runtime/Agent/TranscriptionReader.cs
@@ -69,24 +69,18 @@ public sealed class TranscriptionReader : IDisposable
         var append = _beginReply(Speaker.Npc);
         var filter = new AnnotationFilter();
         var r = reader.ReadIncremental();
-        string lastSeen = null;
         while (true)
         {
             yield return r;
+            if (r.IsEos) break;
 
-            // EOS ticks don't refresh Text — only forward when the reference actually changed.
             var chunk = r.Text;
-            if (!ReferenceEquals(chunk, lastSeen))
+            if (!string.IsNullOrEmpty(chunk))
             {
-                if (!string.IsNullOrEmpty(chunk))
-                {
-                    var filtered = filter.Filter(chunk);
-                    if (!string.IsNullOrEmpty(filtered)) append(filtered);
-                }
-                lastSeen = chunk;
+                var filtered = filter.Filter(chunk);
+                if (!string.IsNullOrEmpty(filtered)) append(filtered);
             }
 
-            if (r.IsEos) break;
             r.Reset();
         }
     }

--- a/Tests/EditMode/DataStreamIncrementalReadTests.cs
+++ b/Tests/EditMode/DataStreamIncrementalReadTests.cs
@@ -86,12 +86,11 @@ namespace LiveKit.EditModeTests
                 Assert.AreEqual(i.ToString(), observed[i], $"Chunk reordering at index {i}.");
         }
 
-        // OnEos races with OnChunk on the FFI thread. After both complete, the lock
-        // must leave the instruction in a consistent state: IsEos visible, no torn
-        // reads of LatestChunk, and the chunks pushed before EOS still drainable
-        // (up to the point where Reset() is correctly disallowed past EOS).
+        // OnEos races with OnChunk on the FFI thread. EOS is an ordered item behind the
+        // chunks, so after both complete the consumer must be able to drain every chunk in
+        // FIFO order before observing end-of-stream — never seeing EOS while data remains.
         [Test]
-        public void OnEos_RacingWithChunks_FinalStateConsistent()
+        public void OnEos_RacingWithChunks_AllChunksDrainThenEos()
         {
             for (int trial = 0; trial < 50; trial++)
             {
@@ -109,20 +108,128 @@ namespace LiveKit.EditModeTests
                 start.Set();
                 producer.Wait(TimeSpan.FromSeconds(5));
 
-                Assert.IsTrue(reader.IsEos, $"Trial {trial}: EOS not observed after producer finished.");
-                // Reading LatestChunk after EOS must never throw an unexpected exception
-                // — the only allowed throw is the StreamError on protocol error, which
-                // we don't simulate here. Specifically: no NullReferenceException, no
-                // collection-modified exception, no torn-read.
+                var observed = new List<string>(100);
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (true)
+                {
+                    while (reader.keepWaiting)
+                    {
+                        if (DateTime.UtcNow > deadline)
+                            Assert.Fail($"Trial {trial}: drain stalled at {observed.Count}/100 — chunk lost or deadlock.");
+                        Thread.Yield();
+                    }
+                    if (reader.IsEos) break;
+                    observed.Add(reader.Value);
+                    reader.Reset();
+                }
+
+                Assert.AreEqual(100, observed.Count,
+                    $"Trial {trial}: EOS observed before all chunks were drained.");
+                for (int i = 0; i < 100; i++)
+                    Assert.AreEqual(i.ToString(), observed[i], $"Trial {trial}: chunk reordering at index {i}.");
+
+                // A clean end-of-stream leaves no chunk to read: LatestChunk returns the
+                // default value and never throws (a torn read would surface here).
                 Assert.DoesNotThrow(() => { var _ = reader.Value; },
                     $"Trial {trial}: reading LatestChunk after EOS race threw unexpectedly.");
+                Assert.IsNull(reader.Value, $"Trial {trial}: expected null chunk at end-of-stream.");
             }
+        }
+
+        // The whole stream — every chunk AND end-of-stream — arrives before the consumer
+        // reads anything (the common small-stream / already-buffered case). Every chunk must
+        // still be delivered before EOS is observed. This is the core regression the
+        // single-queue / EOS-as-terminal-item fix addresses: previously IsEos short-circuited
+        // the buffered chunks and the whole stream was dropped.
+        [Test]
+        public void Burst_AllChunksThenEosBeforeConsumer_AllDrainedThenEos()
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+
+            reader.PushChunk("A");
+            reader.PushChunk("B");
+            reader.PushChunk("C");
+            reader.PushEos();
+
+            CollectionAssert.AreEqual(new[] { "A", "B", "C" }, Drain(reader));
+            Assert.IsTrue(reader.IsEos);
+        }
+
+        // A single chunk followed immediately by end-of-stream — the previous implementation
+        // dropped the chunk because IsEos short-circuited the read on the first iteration.
+        [Test]
+        public void Burst_SingleChunkThenEos_ChunkDelivered()
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+
+            reader.PushChunk("only");
+            reader.PushEos();
+
+            CollectionAssert.AreEqual(new[] { "only" }, Drain(reader));
+            Assert.IsTrue(reader.IsEos);
+        }
+
+        // An empty stream (end-of-stream with no chunks) drains to zero chunks and reports EOS.
+        [Test]
+        public void Burst_EosWithNoChunks_ReportsEosWithNoChunks()
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+
+            reader.PushEos();
+
+            CollectionAssert.IsEmpty(Drain(reader));
+            Assert.IsTrue(reader.IsEos);
+        }
+
+        // Chunks that precede an error close are still delivered in order; the error then
+        // surfaces via IsError/Error once the consumer reaches the terminal marker.
+        [Test]
+        public void Burst_ChunksThenErrorEos_ChunksDrainedThenErrorSurfaces()
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+
+            reader.PushChunk("A");
+            reader.PushChunk("B");
+            reader.PushEos(new LiveKit.Proto.StreamError { Description = "boom" });
+
+            // Read-first drain; break on EOS before reading (an error terminal has no chunk,
+            // and reading it would rethrow the StreamError).
+            var observed = new List<string>();
+            while (!reader.keepWaiting)
+            {
+                if (reader.IsEos) break;
+                observed.Add(reader.Value);
+                reader.Reset();
+            }
+
+            CollectionAssert.AreEqual(new[] { "A", "B" }, observed);
+            Assert.IsTrue(reader.IsEos);
+            Assert.IsTrue(reader.IsError);
+            Assert.AreEqual("boom", reader.Error.Message);
+        }
+
+        // Canonical read-first drain used by the tests above: spin until the reader is
+        // positioned on a chunk or the terminal marker, break on EOS, else read and advance.
+        private static List<string> Drain(TestIncrementalReader reader)
+        {
+            var observed = new List<string>();
+            while (!reader.keepWaiting)
+            {
+                if (reader.IsEos) break;
+                observed.Add(reader.Value);
+                reader.Reset();
+            }
+            return observed;
         }
 
         // OnChunk-after-Reset is the most common interleaving in production: the
         // consumer's coroutine just yielded and called Reset, and an FFI thread
         // pushes a chunk before the consumer wakes. The lock must serialize them
-        // so the new chunk is correctly placed (either as _latestChunk if the
+        // so the new chunk is correctly placed (either as the current item if the
         // queue was empty, or appended to the queue).
         [Test]
         public void OnChunk_RacingWithReset_NoChunkLost()

--- a/Tests/PlayMode/UniTask/StreamUniTaskTests.cs
+++ b/Tests/PlayMode/UniTask/StreamUniTaskTests.cs
@@ -55,9 +55,8 @@ namespace LiveKit.PlayModeTests.UniTaskBridge
             }
         });
 
-        // The current chunk is delivered even when EoS is already set at the time it is read,
-        // then the sequence ends. (Chunks buffered beyond the current one when EoS arrives are
-        // not drainable, because the reader disallows Reset() past EoS.)
+        // The final chunk is delivered even when EoS is already set at the time it is read,
+        // then the sequence ends.
         [UnityTest]
         public System.Collections.IEnumerator AsAsyncEnumerable_DeliversFinalChunkThenEos() => UniTask.ToCoroutine(async () =>
         {
@@ -72,6 +71,27 @@ namespace LiveKit.PlayModeTests.UniTaskBridge
                 observed.Add(chunk);
 
             CollectionAssert.AreEqual(new[] { "only" }, observed);
+        });
+
+        // Every chunk buffered before EoS is drained, even when all of them plus EoS arrive
+        // before the consumer reads anything (the already-buffered burst case). EoS is an
+        // ordered item at the tail of the chunk queue, so it can never short-circuit the data.
+        [UnityTest]
+        public System.Collections.IEnumerator AsAsyncEnumerable_DrainsAllBufferedChunks_WhenEosArrivesFirst() => UniTask.ToCoroutine(async () =>
+        {
+            using var handle = new FfiHandle(IntPtr.Zero);
+            var reader = new TestIncrementalReader(handle);
+
+            reader.PushChunk("A");
+            reader.PushChunk("B");
+            reader.PushChunk("C");
+            reader.PushEos();
+
+            var observed = new List<string>();
+            await foreach (var chunk in reader.AsAsyncEnumerable())
+                observed.Add(chunk);
+
+            CollectionAssert.AreEqual(new[] { "A", "B", "C" }, observed);
         });
 
         // A chunk delivered before the stream errors is observed; the subsequent error EoS


### PR DESCRIPTION
### Background

When a burst of packages plus the EOS trailer arrived at the same time, the incremental reading of the stream was broken. If the stream was marked EOS, but the queue still had chunks, they were ignored.

This PR adds the logic to fix the bug plus tests.  

### Changes

What did you do?

- Fix bug when EOS message could mark the stream as ended, even when queue was non-empty
- Add tests to guard the expected behaviour
- Simplify agent sample code since workaround is not needed anymore 