### PR TITLE
Deprecate sandbox token server and use development token server

### DIFF
--- a/Editor/TokenSourceComponentConfigEditor.cs
+++ b/Editor/TokenSourceComponentConfigEditor.cs
@@ -25,12 +25,12 @@ public class TokenSourceComponentConfigEditor : Editor
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_token"));
                 break;
 
-            case TokenSourceType.Sandbox:
+            case TokenSourceType.Develop:
                 EditorGUILayout.HelpBox(
-                    "Use this for development to create tokens from a sandbox token server. " +
-                    "\nWARNING: ONLY USE THIS OPTION FOR LOCAL DEVELOPMENT, SINCE THE SANDBOX TOKEN SERVER NEEDS NO AUTHENTICATION.",
+                    "Use this for development to create tokens from a development token server. " +
+                    "\nWARNING: ONLY USE THIS OPTION FOR LOCAL DEVELOPMENT, SINCE THE DEVELOPMENT TOKEN SERVER NEEDS NO AUTHENTICATION.",
                     MessageType.Info);
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("_sandboxId"));
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("_tokenServerId"));
                 DrawConnectionOptions();
                 break;
 

--- a/Editor/TokenSourceComponentConfigEditor.cs
+++ b/Editor/TokenSourceComponentConfigEditor.cs
@@ -25,7 +25,7 @@ public class TokenSourceComponentConfigEditor : Editor
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_token"));
                 break;
 
-            case TokenSourceType.Development:
+            case TokenSourceType.DevelopmentTokenServer:
                 EditorGUILayout.HelpBox(
                     "Use this for development to create tokens from a development token server. " +
                     "\nWARNING: ONLY USE THIS OPTION FOR LOCAL DEVELOPMENT, SINCE THE DEVELOPMENT TOKEN SERVER NEEDS NO AUTHENTICATION.",

--- a/Editor/TokenSourceComponentConfigEditor.cs
+++ b/Editor/TokenSourceComponentConfigEditor.cs
@@ -25,7 +25,7 @@ public class TokenSourceComponentConfigEditor : Editor
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("_token"));
                 break;
 
-            case TokenSourceType.Develop:
+            case TokenSourceType.Development:
                 EditorGUILayout.HelpBox(
                     "Use this for development to create tokens from a development token server. " +
                     "\nWARNING: ONLY USE THIS OPTION FOR LOCAL DEVELOPMENT, SINCE THE DEVELOPMENT TOKEN SERVER NEEDS NO AUTHENTICATION.",

--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ To help getting started with tokens, use `TokenSourceComponent.cs` with a `Token
 #### 1. Literal
 Use this to pass a pregenerated server URL and token. Generate tokens via the [LiveKit CLI](https://docs.livekit.io/frontends/build/authentication/custom/#manual-token-creation) or from your [LiveKit Cloud](https://cloud.livekit.io/) project's API key page.
 
-#### 2. Sandbox
-For development and testing. Follow the [sandbox token server guide](https://docs.livekit.io/frontends/build/authentication/sandbox-token-server/) to enable your project's sandbox and get the sandbox ID. Optional connection fields (room name, participant name, agent name, etc.) can be configured in the inspector — leave blank for server defaults.
+#### 2. Develop
+For development and testing. Follow the [development token server guide](https://docs.livekit.io/frontends/build/authentication/sandbox-token-server/) to enable your project's development token server and get the token server ID. Optional connection fields (room name, participant name, agent name, etc.) can be configured in the inspector — leave blank for server defaults.
 
 #### 3. Endpoint
-For production. Point to your own token endpoint URL and add any required authentication headers. Uses the same connection options as Sandbox. See the [endpoint token generation guide](https://docs.livekit.io/frontends/build/authentication/endpoint/).
+For production. Point to your own token endpoint URL and add any required authentication headers. Uses the same connection options as Develop. See the [endpoint token generation guide](https://docs.livekit.io/frontends/build/authentication/endpoint/).
 
 #### Usage
 
@@ -186,7 +186,7 @@ yield return fetch;
 var details = fetch.Result;
 
 // Configurable sources accept TokenSourceFetchOptions per call:
-ITokenSourceConfigurable configurable = new TokenSourceSandbox("<sandbox-id>");
+ITokenSourceConfigurable configurable = new TokenSourceDevelop("<token-server-id>");
 // or: new TokenSourceEndpoint("https://your.token-server/api/token", headers);
 
 var configurableFetch = configurable.FetchConnectionDetails(new TokenSourceFetchOptions { RoomName = "lobby" });

--- a/README.md
+++ b/README.md
@@ -174,20 +174,20 @@ var fetch = _tokenSourceComponent.FetchConnectionDetails(new TokenSourceFetchOpt
 });
 ```
 
-To skip the ScriptableObject entirely, instantiate a token source directly. Each returns the same `TaskYieldInstruction<ConnectionDetails>` from `FetchConnectionDetails`, so it can be yielded, awaited, or `.AsUniTask()`-bridged just like the component:
+To skip the ScriptableObject entirely, create a token source at runtime via the `TokenSource` factory methods. Each returns the same `TaskYieldInstruction<ConnectionDetails>` from `FetchConnectionDetails`, so it can be yielded, awaited, or `.AsUniTask()`-bridged just like the component:
 
 ```cs
 // Fixed sources take no per-call options:
-ITokenSourceFixed source = new TokenSourceLiteral("wss://your.livekit.host", "<join-token>");
-// or: new TokenSourceCustom(async () => await MyAuthFlow());
+ITokenSourceFixed source = TokenSource.Literal("wss://your.livekit.host", "<join-token>");
+// or: TokenSource.Custom(async () => await MyAuthFlow());
 
 var fetch = source.FetchConnectionDetails();
 yield return fetch;
 var details = fetch.Result;
 
 // Configurable sources accept TokenSourceFetchOptions per call:
-ITokenSourceConfigurable configurable = new TokenSourceDevelopment("<token-server-id>");
-// or: new TokenSourceEndpoint("https://your.token-server/api/token", headers);
+ITokenSourceConfigurable configurable = TokenSource.DevelopmentTokenServer("<token-server-id>");
+// or: TokenSource.Endpoint("https://your.token-server/api/token", headers);
 
 var configurableFetch = configurable.FetchConnectionDetails(new TokenSourceFetchOptions { RoomName = "lobby" });
 yield return configurableFetch;

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To help getting started with tokens, use `TokenSourceComponent.cs` with a `Token
 #### 1. Literal
 Use this to pass a pregenerated server URL and token. Generate tokens via the [LiveKit CLI](https://docs.livekit.io/frontends/build/authentication/custom/#manual-token-creation) or from your [LiveKit Cloud](https://cloud.livekit.io/) project's API key page.
 
-#### 2. Development
+#### 2. Development Token Server
 For development and testing. Follow the [development token server guide](https://docs.livekit.io/frontends/build/authentication/sandbox-token-server/) to enable your project's development token server and get the token server ID. Optional connection fields (room name, participant name, agent name, etc.) can be configured in the inspector — leave blank for server defaults.
 
 #### 3. Endpoint

--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ To help getting started with tokens, use `TokenSourceComponent.cs` with a `Token
 #### 1. Literal
 Use this to pass a pregenerated server URL and token. Generate tokens via the [LiveKit CLI](https://docs.livekit.io/frontends/build/authentication/custom/#manual-token-creation) or from your [LiveKit Cloud](https://cloud.livekit.io/) project's API key page.
 
-#### 2. Develop
+#### 2. Development
 For development and testing. Follow the [development token server guide](https://docs.livekit.io/frontends/build/authentication/sandbox-token-server/) to enable your project's development token server and get the token server ID. Optional connection fields (room name, participant name, agent name, etc.) can be configured in the inspector — leave blank for server defaults.
 
 #### 3. Endpoint
-For production. Point to your own token endpoint URL and add any required authentication headers. Uses the same connection options as Develop. See the [endpoint token generation guide](https://docs.livekit.io/frontends/build/authentication/endpoint/).
+For production. Point to your own token endpoint URL and add any required authentication headers. Uses the same connection options as Development. See the [endpoint token generation guide](https://docs.livekit.io/frontends/build/authentication/endpoint/).
 
 #### Usage
 
@@ -186,7 +186,7 @@ yield return fetch;
 var details = fetch.Result;
 
 // Configurable sources accept TokenSourceFetchOptions per call:
-ITokenSourceConfigurable configurable = new TokenSourceDevelop("<token-server-id>");
+ITokenSourceConfigurable configurable = new TokenSourceDevelopment("<token-server-id>");
 // or: new TokenSourceEndpoint("https://your.token-server/api/token", headers);
 
 var configurableFetch = configurable.FetchConnectionDetails(new TokenSourceFetchOptions { RoomName = "lobby" });

--- a/Runtime/Scripts/TokenSource/TokenSource.cs
+++ b/Runtime/Scripts/TokenSource/TokenSource.cs
@@ -9,6 +9,197 @@ using Newtonsoft.Json;
 namespace LiveKit
 {
     /// <summary>
+    /// Factory for the built-in <see cref="ITokenSource"/> implementations. The concrete implementations
+    /// are private; obtain them through the factory methods and work with the returned
+    /// <see cref="ITokenSourceFixed"/> or <see cref="ITokenSourceConfigurable"/>.
+    /// </summary>
+    public static class TokenSource
+    {
+        public delegate Task<ConnectionDetails> CustomTokenFunction();
+
+        /// <summary>
+        /// Returns a fixed server URL and participant token. Suitable when credentials are pregenerated
+        /// (e.g. via the LiveKit CLI or LiveKit Cloud project page).
+        /// </summary>
+        public static ITokenSourceFixed Literal(string serverUrl, string participantToken)
+        {
+            return new LiteralSource(serverUrl, participantToken);
+        }
+
+        /// <summary>
+        /// Posts a JSON request to a token-server endpoint and returns the parsed <see cref="ConnectionDetails"/>.
+        /// The body is built from per-call <see cref="TokenSourceFetchOptions"/> (room name, participant info,
+        /// agent dispatch, etc.). Use for production token servers — see
+        /// https://docs.livekit.io/frontends/build/authentication/endpoint/.
+        /// </summary>
+        public static ITokenSourceConfigurable Endpoint(string endpointUrl, IEnumerable<StringPair> headers)
+        {
+            return new EndpointSource(endpointUrl, headers);
+        }
+
+        /// <summary>
+        /// Delegates connection-detail retrieval to a user-supplied async function. Use this when your
+        /// app already has its own token-fetching code (custom auth flow, cached tokens, etc.).
+        /// </summary>
+        public static ITokenSourceFixed Custom(CustomTokenFunction customTokenFunction)
+        {
+            return new CustomSource(customTokenFunction);
+        }
+
+        [Obsolete("Use TokenSource.DevelopmentTokenServer instead")]
+        public static ITokenSourceConfigurable SandboxTokenServer(string sandboxId)
+        {
+            return DevelopmentTokenServer(sandboxId);
+        }
+
+        /// <summary>
+        /// Convenience <see cref="Endpoint"/> preconfigured for LiveKit Cloud development token servers.
+        /// Intended for development and testing only — see
+        /// https://docs.livekit.io/frontends/build/authentication/sandbox-token-server/.
+        /// </summary>
+        public static ITokenSourceConfigurable DevelopmentTokenServer(string tokenServerId)
+        {
+            return new EndpointSource(
+                "https://cloud-api.livekit.io/api/v2/sandbox/connection-details",
+                new[] { new StringPair { key = "X-Sandbox-ID", value = tokenServerId } });
+        }
+
+        private sealed class LiteralSource : ITokenSourceFixed
+        {
+            private string _serverUrl;
+            private string _participantToken;
+
+            public LiteralSource(string serverUrl, string participantToken)
+            {
+                _serverUrl = serverUrl;
+                _participantToken = participantToken;
+            }
+
+            public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails()
+            {
+                var result = new ConnectionDetails { ServerUrl = _serverUrl, ParticipantToken = _participantToken };
+                return new TaskYieldInstruction<ConnectionDetails>(Task.FromResult(result));
+            }
+        }
+
+        private sealed class CustomSource : ITokenSourceFixed
+        {
+            private CustomTokenFunction _customTokenFunction;
+
+            public CustomSource(CustomTokenFunction customTokenFunction)
+            {
+                _customTokenFunction = customTokenFunction;
+            }
+
+            public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails()
+            {
+                // Route a synchronous throw (or a null return) from the user's function through the
+                // instruction's IsError/Exception, so callers never have to guard the call itself.
+                Task<ConnectionDetails> task;
+                try
+                {
+                    task = _customTokenFunction()
+                        ?? Task.FromException<ConnectionDetails>(
+                            new InvalidOperationException("Custom token function returned a null task"));
+                }
+                catch (Exception e)
+                {
+                    task = Task.FromException<ConnectionDetails>(e);
+                }
+                return new TaskYieldInstruction<ConnectionDetails>(task);
+            }
+        }
+
+        private sealed class EndpointSource : ITokenSourceConfigurable
+        {
+            private string _endpointUrl;
+            IEnumerable<StringPair> _headers;
+            private static readonly HttpClient HttpClient = new HttpClient();
+
+            public EndpointSource(string endpointUrl, IEnumerable<StringPair> headers)
+            {
+                _endpointUrl = endpointUrl;
+                _headers = headers;
+            }
+
+            public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions options)
+            {
+                // Async methods can't return the (non-awaitable) instruction directly, so the actual
+                // request lives in the helper below; the returned task carries any synchronous throw.
+                return new TaskYieldInstruction<ConnectionDetails>(FetchConnectionDetailsAsync(options));
+            }
+
+            private async Task<ConnectionDetails> FetchConnectionDetailsAsync(TokenSourceFetchOptions options)
+            {
+                var requestBody = BuildRequest(options);
+                var jsonBody = JsonConvert.SerializeObject(requestBody);
+
+                var request = new HttpRequestMessage(HttpMethod.Post, _endpointUrl);
+                if (_headers != null)
+                {
+                    foreach (var header in _headers)
+                    {
+                        if (!string.IsNullOrEmpty(header.key))
+                            request.Headers.TryAddWithoutValidation(header.key, header.value);
+                    }
+                }
+                var content = new StringContent(jsonBody, System.Text.Encoding.UTF8);
+                content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+                request.Content = content;
+
+                var response = await HttpClient.SendAsync(request);
+
+                if (!response.IsSuccessStatusCode)
+                    throw new InvalidOperationException($"Token server error: {response.StatusCode}, response: {await response.Content.ReadAsStringAsync()}");
+
+                var jsonContent = await response.Content.ReadAsStringAsync();
+                return JsonConvert.DeserializeObject<ConnectionDetails>(jsonContent);
+            }
+
+            private static TokenSourceRequest BuildRequest(TokenSourceFetchOptions options)
+            {
+                var request = new TokenSourceRequest
+                {
+                    RoomName = NullIfEmpty(options.RoomName),
+                    ParticipantName = NullIfEmpty(options.ParticipantName),
+                    ParticipantIdentity = NullIfEmpty(options.ParticipantIdentity),
+                    ParticipantMetadata = NullIfEmpty(options.ParticipantMetadata),
+                };
+
+                if (options.ParticipantAttributes != null && options.ParticipantAttributes.Count > 0)
+                {
+                    request.ParticipantAttributes = options.ParticipantAttributes
+                        .Where(a => !string.IsNullOrEmpty(a.Key))
+                        .ToDictionary(a => a.Key, a => a.Value);
+                    if (request.ParticipantAttributes.Count == 0)
+                        request.ParticipantAttributes = null;
+                }
+
+                if (!string.IsNullOrEmpty(options.AgentName) || !string.IsNullOrEmpty(options.AgentMetadata) || !string.IsNullOrEmpty(options.AgentDeployment))
+                {
+                    request.RoomConfig = new RoomConfig
+                    {
+                        Agents = new List<AgentDispatch>
+                        {
+                            new AgentDispatch
+                            {
+                                AgentName = NullIfEmpty(options.AgentName),
+                                Metadata = NullIfEmpty(options.AgentMetadata),
+                                Deployment = NullIfEmpty(options.AgentDeployment)
+                            }
+                        }
+                    };
+                }
+
+                return request;
+            }
+
+            private static string NullIfEmpty(string value) =>
+                string.IsNullOrEmpty(value) ? null : value;
+        }
+    }
+
+    /// <summary>
     /// Marker interface for any source of LiveKit <see cref="ConnectionDetails"/>.
     /// Implementations are either <see cref="ITokenSourceFixed"/> or <see cref="ITokenSourceConfigurable"/>.
     /// </summary>
@@ -32,172 +223,5 @@ namespace LiveKit
     public interface ITokenSourceConfigurable : ITokenSource
     {
         public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions options);
-    }
-
-    /// <summary>
-    /// Returns a fixed server URL and participant token. Suitable when credentials are pregenerated
-    /// (e.g. via the LiveKit CLI or LiveKit Cloud project page).
-    /// </summary>
-    public class TokenSourceLiteral : ITokenSourceFixed
-    {
-        private string _serverUrl;
-        private string _participantToken;
-
-        public TokenSourceLiteral(string serverUrl, string participantToken)
-        {
-            _serverUrl = serverUrl;
-            _participantToken = participantToken;
-        }
-
-        public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails()
-        {
-            var result = new ConnectionDetails { ServerUrl = _serverUrl, ParticipantToken = _participantToken };
-            return new TaskYieldInstruction<ConnectionDetails>(Task.FromResult(result));
-        }
-    }
-
-    /// <summary>
-    /// Delegates connection-detail retrieval to a user-supplied async function. Use this when your
-    /// app already has its own token-fetching code (custom auth flow, cached tokens, etc.).
-    /// </summary>
-    public class TokenSourceCustom : ITokenSourceFixed
-    {
-        public delegate Task<ConnectionDetails> CustomTokenFunction();
-
-        private CustomTokenFunction _customTokenFunction;
-
-        public TokenSourceCustom(CustomTokenFunction customTokenFunction)
-        {
-            _customTokenFunction = customTokenFunction;
-        }
-
-        public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails()
-        {
-            // Route a synchronous throw (or a null return) from the user's function through the
-            // instruction's IsError/Exception, so callers never have to guard the call itself.
-            Task<ConnectionDetails> task;
-            try
-            {
-                task = _customTokenFunction()
-                    ?? Task.FromException<ConnectionDetails>(
-                        new InvalidOperationException("Custom token function returned a null task"));
-            }
-            catch (Exception e)
-            {
-                task = Task.FromException<ConnectionDetails>(e);
-            }
-            return new TaskYieldInstruction<ConnectionDetails>(task);
-        }
-    }
-
-    /// <summary>
-    /// Posts a JSON request to a token-server endpoint and returns the parsed <see cref="ConnectionDetails"/>.
-    /// The body is built from per-call <see cref="TokenSourceFetchOptions"/> (room name, participant info,
-    /// agent dispatch, etc.). Use for production token servers — see
-    /// https://docs.livekit.io/frontends/build/authentication/endpoint/.
-    /// </summary>
-    public class TokenSourceEndpoint : ITokenSourceConfigurable
-    {
-        private string _endpointUrl;
-        IEnumerable<StringPair> _headers;
-        private static readonly HttpClient HttpClient = new HttpClient();
-
-        public TokenSourceEndpoint(string endpointUrl, IEnumerable<StringPair> headers)
-        {
-            _endpointUrl = endpointUrl;
-            _headers = headers;
-        }
-
-        public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions options)
-        {
-            // Async methods can't return the (non-awaitable) instruction directly, so the actual
-            // request lives in the helper below; the returned task carries any synchronous throw.
-            return new TaskYieldInstruction<ConnectionDetails>(FetchConnectionDetailsAsync(options));
-        }
-
-        private async Task<ConnectionDetails> FetchConnectionDetailsAsync(TokenSourceFetchOptions options)
-        {
-            var requestBody = BuildRequest(options);
-            var jsonBody = JsonConvert.SerializeObject(requestBody);
-
-            var request = new HttpRequestMessage(HttpMethod.Post, _endpointUrl);
-            if (_headers != null)
-            {
-                foreach (var header in _headers)
-                {
-                    if (!string.IsNullOrEmpty(header.key))
-                        request.Headers.TryAddWithoutValidation(header.key, header.value);
-                }
-            }
-            var content = new StringContent(jsonBody, System.Text.Encoding.UTF8);
-            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-            request.Content = content;
-
-            var response = await HttpClient.SendAsync(request);
-
-            if (!response.IsSuccessStatusCode)
-                throw new InvalidOperationException($"Token server error: {response.StatusCode}, response: {await response.Content.ReadAsStringAsync()}");
-
-            var jsonContent = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<ConnectionDetails>(jsonContent);
-        }
-
-        private static TokenSourceRequest BuildRequest(TokenSourceFetchOptions options)
-        {
-            var request = new TokenSourceRequest
-            {
-                RoomName = NullIfEmpty(options.RoomName),
-                ParticipantName = NullIfEmpty(options.ParticipantName),
-                ParticipantIdentity = NullIfEmpty(options.ParticipantIdentity),
-                ParticipantMetadata = NullIfEmpty(options.ParticipantMetadata),
-            };
-
-            if (options.ParticipantAttributes != null && options.ParticipantAttributes.Count > 0)
-            {
-                request.ParticipantAttributes = options.ParticipantAttributes
-                    .Where(a => !string.IsNullOrEmpty(a.Key))
-                    .ToDictionary(a => a.Key, a => a.Value);
-                if (request.ParticipantAttributes.Count == 0)
-                    request.ParticipantAttributes = null;
-            }
-
-            if (!string.IsNullOrEmpty(options.AgentName) || !string.IsNullOrEmpty(options.AgentMetadata) || !string.IsNullOrEmpty(options.AgentDeployment))
-            {
-                request.RoomConfig = new RoomConfig
-                {
-                    Agents = new List<AgentDispatch>
-                    {
-                        new AgentDispatch
-                        {
-                            AgentName = NullIfEmpty(options.AgentName),
-                            Metadata = NullIfEmpty(options.AgentMetadata),
-                            Deployment = NullIfEmpty(options.AgentDeployment)
-                        }
-                    }
-                };
-            }
-
-            return request;
-        }
-
-        private static string NullIfEmpty(string value) =>
-            string.IsNullOrEmpty(value) ? null : value;
-    }
-
-    
-    [Obsolete("Use TokenSourceDevelopment instead")]
-    public class TokenSourceSandbox : TokenSourceDevelopment
-    {
-        public TokenSourceSandbox(string sandboxId) : base(sandboxId) {}
-    }
-
-    /// <summary>
-    /// Convenience <see cref="TokenSourceEndpoint"/> preconfigured for LiveKit Cloud development token servers.
-    /// Intended for development and testing only — see
-    /// https://docs.livekit.io/frontends/build/authentication/sandbox-token-server/.
-    /// </summary>
-    public class TokenSourceDevelopment : TokenSourceEndpoint
-    {
-        public TokenSourceDevelopment(string tokenServerId) : base("https://cloud-api.livekit.io/api/v2/sandbox/connection-details", new[] { new StringPair { key = "X-Sandbox-ID", value = tokenServerId } }) {}
     }
 }

--- a/Runtime/Scripts/TokenSource/TokenSource.cs
+++ b/Runtime/Scripts/TokenSource/TokenSource.cs
@@ -17,6 +17,8 @@ namespace LiveKit
     {
         public delegate Task<ConnectionDetails> CustomTokenFunction();
 
+        internal const string DevelopmentTokenServerUrl = "https://cloud-api.livekit.io/api/v2/sandbox/connection-details";
+
         /// <summary>
         /// Returns a fixed server URL and participant token. Suitable when credentials are pregenerated
         /// (e.g. via the LiveKit CLI or LiveKit Cloud project page).
@@ -60,7 +62,7 @@ namespace LiveKit
         public static ITokenSourceConfigurable DevelopmentTokenServer(string tokenServerId)
         {
             return new EndpointSource(
-                "https://cloud-api.livekit.io/api/v2/sandbox/connection-details",
+                DevelopmentTokenServerUrl,
                 new[] { new StringPair { key = "X-Sandbox-ID", value = tokenServerId } });
         }
 
@@ -223,5 +225,57 @@ namespace LiveKit
     public interface ITokenSourceConfigurable : ITokenSource
     {
         public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions options);
+    }
+
+    [Obsolete("Use TokenSource.Literal(...) instead")]
+    public class TokenSourceLiteral : ITokenSourceFixed
+    {
+        private readonly ITokenSourceFixed _inner;
+
+        public TokenSourceLiteral(string serverUrl, string participantToken)
+        {
+            _inner = TokenSource.Literal(serverUrl, participantToken);
+        }
+
+        public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails() => _inner.FetchConnectionDetails();
+    }
+
+    [Obsolete("Use TokenSource.Custom(...) instead")]
+    public class TokenSourceCustom : ITokenSourceFixed
+    {
+        // v2.0.0 declared the delegate nested here; keep it so explicit
+        // TokenSourceCustom.CustomTokenFunction references still compile.
+        public delegate Task<ConnectionDetails> CustomTokenFunction();
+
+        private readonly ITokenSourceFixed _inner;
+
+        public TokenSourceCustom(CustomTokenFunction customTokenFunction)
+        {
+            // Lambda (not .Invoke) so a null delegate surfaces at fetch time via
+            // IsError/Exception, matching v2.0.0 behavior, not as a ctor throw.
+            _inner = TokenSource.Custom(() => customTokenFunction());
+        }
+
+        public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails() => _inner.FetchConnectionDetails();
+    }
+
+    [Obsolete("Use TokenSource.Endpoint(...) instead")]
+    public class TokenSourceEndpoint : ITokenSourceConfigurable
+    {
+        private readonly ITokenSourceConfigurable _inner;
+
+        public TokenSourceEndpoint(string endpointUrl, IEnumerable<StringPair> headers)
+        {
+            _inner = TokenSource.Endpoint(endpointUrl, headers);
+        }
+
+        public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions options) => _inner.FetchConnectionDetails(options);
+    }
+
+    [Obsolete("Use TokenSource.DevelopmentTokenServer(...) instead")]
+    public class TokenSourceSandbox : TokenSourceEndpoint
+    {
+        public TokenSourceSandbox(string sandboxId)
+            : base(TokenSource.DevelopmentTokenServerUrl, new[] { new StringPair { key = "X-Sandbox-ID", value = sandboxId } }) {}
     }
 }

--- a/Runtime/Scripts/TokenSource/TokenSource.cs
+++ b/Runtime/Scripts/TokenSource/TokenSource.cs
@@ -185,8 +185,8 @@ namespace LiveKit
     }
 
     
-    [Obsolete("Use TokenSourceDevelop instead")]
-    public class TokenSourceSandbox : TokenSourceDevelop
+    [Obsolete("Use TokenSourceDevelopment instead")]
+    public class TokenSourceSandbox : TokenSourceDevelopment
     {
         public TokenSourceSandbox(string sandboxId) : base(sandboxId) {}
     }
@@ -196,8 +196,8 @@ namespace LiveKit
     /// Intended for development and testing only — see
     /// https://docs.livekit.io/frontends/build/authentication/sandbox-token-server/.
     /// </summary>
-    public class TokenSourceDevelop : TokenSourceEndpoint
+    public class TokenSourceDevelopment : TokenSourceEndpoint
     {
-        public TokenSourceDevelop(string tokenServerId) : base("https://cloud-api.livekit.io/api/v2/sandbox/connection-details", new[] { new StringPair { key = "X-Sandbox-ID", value = tokenServerId } }) {}
+        public TokenSourceDevelopment(string tokenServerId) : base("https://cloud-api.livekit.io/api/v2/sandbox/connection-details", new[] { new StringPair { key = "X-Sandbox-ID", value = tokenServerId } }) {}
     }
 }

--- a/Runtime/Scripts/TokenSource/TokenSource.cs
+++ b/Runtime/Scripts/TokenSource/TokenSource.cs
@@ -25,7 +25,7 @@ namespace LiveKit
         /// </summary>
         public static ITokenSourceFixed Literal(string serverUrl, string participantToken)
         {
-            return new LiteralSource(serverUrl, participantToken);
+            return new TokenSourceLiteral(serverUrl, participantToken);
         }
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace LiveKit
         /// </summary>
         public static ITokenSourceConfigurable Endpoint(string endpointUrl, IEnumerable<StringPair> headers)
         {
-            return new EndpointSource(endpointUrl, headers);
+            return new TokenSourceEndpoint(endpointUrl, headers);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace LiveKit
         /// </summary>
         public static ITokenSourceFixed Custom(CustomTokenFunction customTokenFunction)
         {
-            return new CustomSource(customTokenFunction);
+            return new TokenSourceCustom(customTokenFunction);
         }
 
         [Obsolete("Use TokenSource.DevelopmentTokenServer instead")]
@@ -61,17 +61,17 @@ namespace LiveKit
         /// </summary>
         public static ITokenSourceConfigurable DevelopmentTokenServer(string tokenServerId)
         {
-            return new EndpointSource(
+            return new TokenSourceEndpoint(
                 DevelopmentTokenServerUrl,
                 new[] { new StringPair { key = "X-Sandbox-ID", value = tokenServerId } });
         }
 
-        private sealed class LiteralSource : ITokenSourceFixed
+        private sealed class TokenSourceLiteral : ITokenSourceFixed
         {
             private string _serverUrl;
             private string _participantToken;
 
-            public LiteralSource(string serverUrl, string participantToken)
+            public TokenSourceLiteral(string serverUrl, string participantToken)
             {
                 _serverUrl = serverUrl;
                 _participantToken = participantToken;
@@ -84,11 +84,11 @@ namespace LiveKit
             }
         }
 
-        private sealed class CustomSource : ITokenSourceFixed
+        private sealed class TokenSourceCustom : ITokenSourceFixed
         {
             private CustomTokenFunction _customTokenFunction;
 
-            public CustomSource(CustomTokenFunction customTokenFunction)
+            public TokenSourceCustom(CustomTokenFunction customTokenFunction)
             {
                 _customTokenFunction = customTokenFunction;
             }
@@ -112,13 +112,13 @@ namespace LiveKit
             }
         }
 
-        private sealed class EndpointSource : ITokenSourceConfigurable
+        private sealed class TokenSourceEndpoint : ITokenSourceConfigurable
         {
             private string _endpointUrl;
             IEnumerable<StringPair> _headers;
             private static readonly HttpClient HttpClient = new HttpClient();
 
-            public EndpointSource(string endpointUrl, IEnumerable<StringPair> headers)
+            public TokenSourceEndpoint(string endpointUrl, IEnumerable<StringPair> headers)
             {
                 _endpointUrl = endpointUrl;
                 _headers = headers;

--- a/Runtime/Scripts/TokenSource/TokenSource.cs
+++ b/Runtime/Scripts/TokenSource/TokenSource.cs
@@ -184,13 +184,20 @@ namespace LiveKit
             string.IsNullOrEmpty(value) ? null : value;
     }
 
+    
+    [Obsolete("Use TokenSourceDevelop instead")]
+    public class TokenSourceSandbox : TokenSourceDevelop
+    {
+        public TokenSourceSandbox(string sandboxId) : base(sandboxId) {}
+    }
+
     /// <summary>
-    /// Convenience <see cref="TokenSourceEndpoint"/> preconfigured for LiveKit Cloud sandbox token servers.
+    /// Convenience <see cref="TokenSourceEndpoint"/> preconfigured for LiveKit Cloud development token servers.
     /// Intended for development and testing only — see
     /// https://docs.livekit.io/frontends/build/authentication/sandbox-token-server/.
     /// </summary>
-    public class TokenSourceSandbox : TokenSourceEndpoint
+    public class TokenSourceDevelop : TokenSourceEndpoint
     {
-        public TokenSourceSandbox(string sandboxId) : base("https://cloud-api.livekit.io/api/v2/sandbox/connection-details", new[] { new StringPair { key = "X-Sandbox-ID", value = sandboxId } }) {}
+        public TokenSourceDevelop(string tokenServerId) : base("https://cloud-api.livekit.io/api/v2/sandbox/connection-details", new[] { new StringPair { key = "X-Sandbox-ID", value = tokenServerId } }) {}
     }
 }

--- a/Runtime/Scripts/TokenSource/TokenSource.cs
+++ b/Runtime/Scripts/TokenSource/TokenSource.cs
@@ -227,6 +227,10 @@ namespace LiveKit
         public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions options);
     }
 
+    #region Old constructors
+    // For backwards compatibility the old public constructors are still here but deprecated / obsolete. 
+    // Delete when doing a new major release.
+
     [Obsolete("Use TokenSource.Literal(...) instead")]
     public class TokenSourceLiteral : ITokenSourceFixed
     {
@@ -278,4 +282,6 @@ namespace LiveKit
         public TokenSourceSandbox(string sandboxId)
             : base(TokenSource.DevelopmentTokenServerUrl, new[] { new StringPair { key = "X-Sandbox-ID", value = sandboxId } }) {}
     }
+
+    #endregion
 }

--- a/Runtime/Scripts/TokenSource/TokenSource.cs
+++ b/Runtime/Scripts/TokenSource/TokenSource.cs
@@ -68,8 +68,8 @@ namespace LiveKit
 
         private sealed class TokenSourceLiteral : ITokenSourceFixed
         {
-            private string _serverUrl;
-            private string _participantToken;
+            private readonly string _serverUrl;
+            private readonly string _participantToken;
 
             public TokenSourceLiteral(string serverUrl, string participantToken)
             {
@@ -86,7 +86,7 @@ namespace LiveKit
 
         private sealed class TokenSourceCustom : ITokenSourceFixed
         {
-            private CustomTokenFunction _customTokenFunction;
+            private readonly CustomTokenFunction _customTokenFunction;
 
             public TokenSourceCustom(CustomTokenFunction customTokenFunction)
             {
@@ -114,14 +114,14 @@ namespace LiveKit
 
         private sealed class TokenSourceEndpoint : ITokenSourceConfigurable
         {
-            private string _endpointUrl;
-            IEnumerable<StringPair> _headers;
+            private readonly string _endpointUrl;
+            private readonly IReadOnlyList<StringPair> _headers;
             private static readonly HttpClient HttpClient = new HttpClient();
 
             public TokenSourceEndpoint(string endpointUrl, IEnumerable<StringPair> headers)
             {
                 _endpointUrl = endpointUrl;
-                _headers = headers;
+                _headers = headers?.ToList() ?? (IReadOnlyList<StringPair>)Array.Empty<StringPair>();
             }
 
             public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions options)
@@ -136,20 +136,17 @@ namespace LiveKit
                 var requestBody = BuildRequest(options);
                 var jsonBody = JsonConvert.SerializeObject(requestBody);
 
-                var request = new HttpRequestMessage(HttpMethod.Post, _endpointUrl);
-                if (_headers != null)
+                using var request = new HttpRequestMessage(HttpMethod.Post, _endpointUrl);
+                foreach (var header in _headers)
                 {
-                    foreach (var header in _headers)
-                    {
-                        if (!string.IsNullOrEmpty(header.key))
-                            request.Headers.TryAddWithoutValidation(header.key, header.value);
-                    }
+                    if (!string.IsNullOrEmpty(header.key))
+                        request.Headers.TryAddWithoutValidation(header.key, header.value);
                 }
                 var content = new StringContent(jsonBody, System.Text.Encoding.UTF8);
                 content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
                 request.Content = content;
 
-                var response = await HttpClient.SendAsync(request);
+                using var response = await HttpClient.SendAsync(request);
 
                 if (!response.IsSuccessStatusCode)
                     throw new InvalidOperationException($"Token server error: {response.StatusCode}, response: {await response.Content.ReadAsStringAsync()}");

--- a/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
@@ -10,7 +10,7 @@ namespace LiveKit
     /// <summary>
     /// MonoBehaviour wrapper that builds an <see cref="ITokenSource"/> from an inspector-assigned
     /// <see cref="TokenSourceComponentConfig"/> ScriptableObject. To skip the asset entirely, instantiate
-    /// <see cref="TokenSourceLiteral"/>, <see cref="TokenSourceDevelop"/>, <see cref="TokenSourceEndpoint"/>,
+    /// <see cref="TokenSourceLiteral"/>, <see cref="TokenSourceDevelopment"/>, <see cref="TokenSourceEndpoint"/>,
     /// or <see cref="TokenSourceCustom"/> directly at runtime.
     /// </summary>
     public class TokenSourceComponent : MonoBehaviour
@@ -34,8 +34,8 @@ namespace LiveKit
 
             switch (_config.TokenSourceType)
             {
-                case TokenSourceType.Develop:
-                    _tokenSource = new TokenSourceDevelop(_config.TokenServerId);
+                case TokenSourceType.Development:
+                    _tokenSource = new TokenSourceDevelopment(_config.TokenServerId);
                     break;
 
                 case TokenSourceType.Endpoint:

--- a/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
@@ -10,7 +10,7 @@ namespace LiveKit
     /// <summary>
     /// MonoBehaviour wrapper that builds an <see cref="ITokenSource"/> from an inspector-assigned
     /// <see cref="TokenSourceComponentConfig"/> ScriptableObject. To skip the asset entirely, instantiate
-    /// <see cref="TokenSourceLiteral"/>, <see cref="TokenSourceSandbox"/>, <see cref="TokenSourceEndpoint"/>,
+    /// <see cref="TokenSourceLiteral"/>, <see cref="TokenSourceDevelop"/>, <see cref="TokenSourceEndpoint"/>,
     /// or <see cref="TokenSourceCustom"/> directly at runtime.
     /// </summary>
     public class TokenSourceComponent : MonoBehaviour
@@ -34,8 +34,8 @@ namespace LiveKit
 
             switch (_config.TokenSourceType)
             {
-                case TokenSourceType.Sandbox:
-                    _tokenSource = new TokenSourceSandbox(_config.SandboxId);
+                case TokenSourceType.Develop:
+                    _tokenSource = new TokenSourceDevelop(_config.TokenServerId);
                     break;
 
                 case TokenSourceType.Endpoint:

--- a/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponent.cs
@@ -9,9 +9,10 @@ namespace LiveKit
 {
     /// <summary>
     /// MonoBehaviour wrapper that builds an <see cref="ITokenSource"/> from an inspector-assigned
-    /// <see cref="TokenSourceComponentConfig"/> ScriptableObject. To skip the asset entirely, instantiate
-    /// <see cref="TokenSourceLiteral"/>, <see cref="TokenSourceDevelopment"/>, <see cref="TokenSourceEndpoint"/>,
-    /// or <see cref="TokenSourceCustom"/> directly at runtime.
+    /// <see cref="TokenSourceComponentConfig"/> ScriptableObject. To skip the asset entirely, create a
+    /// source at runtime via the <see cref="TokenSource"/> factory methods (<see cref="TokenSource.Literal"/>,
+    /// <see cref="TokenSource.DevelopmentTokenServer"/>, <see cref="TokenSource.Endpoint"/>,
+    /// or <see cref="TokenSource.Custom"/>).
     /// </summary>
     public class TokenSourceComponent : MonoBehaviour
     {
@@ -34,16 +35,16 @@ namespace LiveKit
 
             switch (_config.TokenSourceType)
             {
-                case TokenSourceType.Development:
-                    _tokenSource = new TokenSourceDevelopment(_config.TokenServerId);
+                case TokenSourceType.DevelopmentTokenServer:
+                    _tokenSource = TokenSource.DevelopmentTokenServer(_config.TokenServerId);
                     break;
 
                 case TokenSourceType.Endpoint:
-                    _tokenSource = new TokenSourceEndpoint(_config.EndpointUrl, _config.EndpointHeaders);
+                    _tokenSource = TokenSource.Endpoint(_config.EndpointUrl, _config.EndpointHeaders);
                     break;
 
                 case TokenSourceType.Literal:
-                    _tokenSource = new TokenSourceLiteral(_config.ServerUrl, _config.Token);    
+                    _tokenSource = TokenSource.Literal(_config.ServerUrl, _config.Token);    
                     break;
 
                 default:
@@ -55,7 +56,8 @@ namespace LiveKit
         /// Fetches connection details, merging per-call <paramref name="options"/> over the asset-backed
         /// <see cref="TokenSourceComponentConfig"/>. For each field, a value provided on <paramref name="options"/>
         /// overrides the config value (empty strings are treated as unset and fall through to the config).
-        /// Ignored for fixed token sources (<see cref="TokenSourceLiteral"/>, <see cref="TokenSourceCustom"/>).
+        /// Ignored for fixed token sources (<see cref="ITokenSourceFixed"/>, i.e. those created via
+        /// <see cref="TokenSource.Literal"/> or <see cref="TokenSource.Custom"/>).
         /// </summary>
         public TaskYieldInstruction<ConnectionDetails> FetchConnectionDetails(TokenSourceFetchOptions options)
         {

--- a/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
@@ -7,7 +7,7 @@ namespace LiveKit
     public enum TokenSourceType
     {
         Literal,
-        Sandbox,
+        Develop,
         Endpoint
     }
 
@@ -27,14 +27,14 @@ namespace LiveKit
         [SerializeField] private string _serverUrl;
         [SerializeField] private string _token;
 
-        // Sandbox fields
-        [SerializeField] private string _sandboxId;
+        // Develop fields
+        [SerializeField] private string _tokenServerId;
 
         // Endpoint fields
         [SerializeField] private string _endpointUrl;
         [SerializeField] private List<StringPair> _endpointHeaders;
 
-        // Shared connection options (Sandbox + Endpoint)
+        // Shared connection options (Develop + Endpoint)
         [SerializeField] private string _roomName;
         [SerializeField] private string _participantName;
         [SerializeField] private string _participantIdentity;
@@ -50,8 +50,8 @@ namespace LiveKit
         public string ServerUrl => _serverUrl;
         public string Token => _token;
 
-        // Sandbox
-        public string SandboxId => _sandboxId?.Trim('"');
+        // Develop
+        public string TokenServerId => _tokenServerId?.Trim('"');
 
         // Endpoint
         public string EndpointUrl => _endpointUrl;
@@ -70,7 +70,7 @@ namespace LiveKit
         public bool IsValid => _tokenSourceType switch
         {
             TokenSourceType.Literal => !string.IsNullOrEmpty(ServerUrl) && ServerUrl.StartsWith("ws") && !string.IsNullOrEmpty(Token),
-            TokenSourceType.Sandbox => !string.IsNullOrEmpty(SandboxId),
+            TokenSourceType.Develop => !string.IsNullOrEmpty(TokenServerId),
             TokenSourceType.Endpoint => !string.IsNullOrEmpty(EndpointUrl),
             _ => false
         };

--- a/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace LiveKit
 {
@@ -28,6 +29,7 @@ namespace LiveKit
         [SerializeField] private string _token;
 
         // Development fields
+        [FormerlySerializedAs("_sandboxId")]
         [SerializeField] private string _tokenServerId;
 
         // Endpoint fields

--- a/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
@@ -7,7 +7,7 @@ namespace LiveKit
     public enum TokenSourceType
     {
         Literal,
-        Develop,
+        Development,
         Endpoint
     }
 
@@ -27,14 +27,14 @@ namespace LiveKit
         [SerializeField] private string _serverUrl;
         [SerializeField] private string _token;
 
-        // Develop fields
+        // Development fields
         [SerializeField] private string _tokenServerId;
 
         // Endpoint fields
         [SerializeField] private string _endpointUrl;
         [SerializeField] private List<StringPair> _endpointHeaders;
 
-        // Shared connection options (Develop + Endpoint)
+        // Shared connection options (Development + Endpoint)
         [SerializeField] private string _roomName;
         [SerializeField] private string _participantName;
         [SerializeField] private string _participantIdentity;
@@ -50,7 +50,7 @@ namespace LiveKit
         public string ServerUrl => _serverUrl;
         public string Token => _token;
 
-        // Develop
+        // Development
         public string TokenServerId => _tokenServerId?.Trim('"');
 
         // Endpoint
@@ -70,7 +70,7 @@ namespace LiveKit
         public bool IsValid => _tokenSourceType switch
         {
             TokenSourceType.Literal => !string.IsNullOrEmpty(ServerUrl) && ServerUrl.StartsWith("ws") && !string.IsNullOrEmpty(Token),
-            TokenSourceType.Develop => !string.IsNullOrEmpty(TokenServerId),
+            TokenSourceType.Development => !string.IsNullOrEmpty(TokenServerId),
             TokenSourceType.Endpoint => !string.IsNullOrEmpty(EndpointUrl),
             _ => false
         };

--- a/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
+++ b/Runtime/Scripts/TokenSource/TokenSourceComponentConfig.cs
@@ -8,7 +8,7 @@ namespace LiveKit
     public enum TokenSourceType
     {
         Literal,
-        Development,
+        DevelopmentTokenServer,
         Endpoint
     }
 
@@ -72,7 +72,7 @@ namespace LiveKit
         public bool IsValid => _tokenSourceType switch
         {
             TokenSourceType.Literal => !string.IsNullOrEmpty(ServerUrl) && ServerUrl.StartsWith("ws") && !string.IsNullOrEmpty(Token),
-            TokenSourceType.Development => !string.IsNullOrEmpty(TokenServerId),
+            TokenSourceType.DevelopmentTokenServer => !string.IsNullOrEmpty(TokenServerId),
             TokenSourceType.Endpoint => !string.IsNullOrEmpty(EndpointUrl),
             _ => false
         };

--- a/Samples~/Agents/README.md
+++ b/Samples~/Agents/README.md
@@ -22,7 +22,7 @@ To switch from the default agent to your own, you first need a LiveKit agent to 
 
 Second, you need a token server. For development, the easiest option is the development token server: enable it from your project's Options on the Settings page in LiveKit Cloud and copy the token server ID.
 
-Then create a new TokenSoureComponentConfig asset for your development token server and reference it in the scene on the `TokenSourceComponent` script instead of the `HomepageAgent.asset`:
+Then create a new TokenSourceComponentConfig asset for your development token server and reference it in the scene on the `TokenSourceComponent` script instead of the `HomepageAgent.asset`:
 
 ### Common sample package
 

--- a/Samples~/Agents/README.md
+++ b/Samples~/Agents/README.md
@@ -20,9 +20,9 @@ The app is configured to connect to the LiveKit homepage agent by default, which
 
 To switch from the default agent to your own, you first need a LiveKit agent to speak with. For a no-code setup, use the [Agent Builder](https://docs.livekit.io/agents/start/builder/). For more customization, try our starter agent for [Python](https://github.com/livekit-examples/agent-starter-python), [Node.js](https://github.com/livekit-examples/agent-starter-node), or [create your own from scratch](https://docs.livekit.io/agents/start/voice-ai/).
 
-Second, you need a token server. For development, the easiest option is the sandbox token server: enable it from your project's Options on the Settings page in LiveKit Cloud and copy the sandboxId.
+Second, you need a token server. For development, the easiest option is the development token server: enable it from your project's Options on the Settings page in LiveKit Cloud and copy the token server ID.
 
-Then create a new TokenSoureComponentConfig asset for your sandbox and reference it in the scene on the `TokenSourceComponent` script instead of the `HomepageAgent.asset`:
+Then create a new TokenSoureComponentConfig asset for your development token server and reference it in the scene on the `TokenSourceComponent` script instead of the `HomepageAgent.asset`:
 
 ### Common sample package
 


### PR DESCRIPTION
### Background

Deprecating "Sandbox" token source and renaming it to development token source. 

### Changes

- Obsolete `TokenSourceSandbox` everywhere
- Alias new `TokenSourceDevelopment`
- Update docs

Newer changes:
- Align with JS SDK to use static factory pattern