### PR TITLE
Add public audio output routing API surface

### DIFF
--- a/Runtime/Scripts/Audio/PlatformAudio.cs
+++ b/Runtime/Scripts/Audio/PlatformAudio.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using LiveKit.Proto;
 using LiveKit.Internal;
 using LiveKit.Internal.FFI.Requests;
@@ -35,6 +36,31 @@ namespace LiveKit
 #endif
 
     /// <summary>
+    /// The kind of audio output device, used for ranked routing policies on mobile
+    /// platforms (see <see cref="PlatformAudio.OutputPreference"/>).
+    ///
+    /// The numeric values mirror the planned FFI protocol enum (AudioDeviceKind) one-to-one
+    /// so a future FFI-backed implementation maps without translation. Do not renumber.
+    /// </summary>
+    public enum AudioOutputKind
+    {
+        /// <summary>The platform did not report a device type.</summary>
+        Unknown = 0,
+        /// <summary>The phone's built-in earpiece (receiver).</summary>
+        Earpiece = 1,
+        /// <summary>The built-in loudspeaker.</summary>
+        Speaker = 2,
+        /// <summary>A wired headset or headphones.</summary>
+        WiredHeadset = 3,
+        /// <summary>A Bluetooth audio device.</summary>
+        Bluetooth = 4,
+        /// <summary>A USB audio device.</summary>
+        Usb = 5,
+        /// <summary>A hearing aid.</summary>
+        HearingAid = 6,
+    }
+
+    /// <summary>
     /// Information about an audio device (microphone or speaker).
     /// </summary>
     public struct AudioDevice
@@ -49,6 +75,17 @@ namespace LiveKit
         /// over index for device selection.
         /// </summary>
         public string Guid;
+        /// <summary>
+        /// The kind of output this device represents. <see cref="AudioOutputKind.Unknown"/>
+        /// where the platform does not report a type — currently all devices: no routing
+        /// backend classifies devices yet.
+        /// </summary>
+        public AudioOutputKind Kind;
+        /// <summary>
+        /// Whether this device is the active output route. Only meaningful once a platform
+        /// routing backend reports selection state — currently always false.
+        /// </summary>
+        public bool IsSelected;
     }
 
     /// <summary>
@@ -73,7 +110,18 @@ namespace LiveKit
     {
         internal readonly FfiHandle Handle;
         private readonly PlatformAudioInfo _info;
+        private readonly IRouteController _routeController;
+        private readonly SynchronizationContext _syncContext;
+        private List<AudioOutputKind> _outputPreference = new List<AudioOutputKind>(DefaultOutputPreference);
         private bool _disposed = false;
+
+        private static readonly AudioOutputKind[] DefaultOutputPreference =
+        {
+            AudioOutputKind.Bluetooth,
+            AudioOutputKind.WiredHeadset,
+            AudioOutputKind.Speaker,
+            AudioOutputKind.Earpiece,
+        };
 
         /// <summary>
         /// Number of available recording (microphone) devices.
@@ -118,7 +166,22 @@ namespace LiveKit
             Handle = FfiHandle.FromOwnedHandle(platformAudio.Handle);
             _info = platformAudio.Info;
 
+            _syncContext = SynchronizationContext.Current;
+            _routeController = CreateRouteController();
+            _routeController.DevicesChanged += OnRouteControllerDevicesChanged;
+
             Utils.Debug($"PlatformAudio created: {RecordingDeviceCount} recording devices, {PlayoutDeviceCount} playout devices");
+        }
+
+        private IRouteController CreateRouteController()
+        {
+#if UNITY_ANDROID && !UNITY_EDITOR
+            return new UnsupportedRouteController(this, "Android");
+#elif UNITY_IOS && !UNITY_EDITOR
+            return new UnsupportedRouteController(this, "iOS");
+#else
+            return new DesktopRouteController(this);
+#endif
         }
 
         /// <summary>
@@ -146,6 +209,16 @@ namespace LiveKit
         /// Thrown if device enumeration failed.
         /// </exception>
         public (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevices()
+        {
+            return _routeController.GetDevices();
+        }
+
+        /// <summary>
+        /// Device enumeration through the FFI, shared by the route controllers.
+        /// <see cref="AudioDevice.Kind"/> and <see cref="AudioDevice.IsSelected"/> are not
+        /// reported by the FFI and stay at their defaults (Unknown / false).
+        /// </summary>
+        internal (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevicesViaFfi()
         {
             using var request = FFIBridge.Instance.NewRequest<GetAudioDevicesRequest>();
             request.request.PlatformAudioHandle = (ulong)Handle.DangerousGetHandle();
@@ -177,6 +250,199 @@ namespace LiveKit
             }
 
             return (recording, playout);
+        }
+
+        /// <summary>
+        /// Ranked automatic output routing policy, most preferred first. When no explicit
+        /// output override is active (<see cref="SelectOutput"/>), the platform routes to
+        /// the highest-ranked kind that has a connected device.
+        ///
+        /// Default: Bluetooth > WiredHeadset > Speaker > Earpiece.
+        ///
+        /// Precedence with <see cref="IsSpeakerOutputPreferred"/>: this list is the single
+        /// source of truth; the bool is convenience sugar that only rewrites the relative
+        /// order of <see cref="AudioOutputKind.Speaker"/> and
+        /// <see cref="AudioOutputKind.Earpiece"/> inside this list, and reading the bool
+        /// reads their current relative order. There is no separate speaker-preference state.
+        ///
+        /// Platform notes: on iOS, external devices (Bluetooth, wired) always take priority
+        /// over the built-in outputs, so the Speaker/Earpiece relative order — i.e.
+        /// <see cref="IsSpeakerOutputPreferred"/> — is the only part of the ranking with an
+        /// effect. On Android the full ranking applies. On desktop, output is selected
+        /// per device (<see cref="SelectOutput"/> / <see cref="SetPlayoutDevice(string)"/>)
+        /// and the ranking has no routing effect. The mobile routing backends are not
+        /// implemented yet in this version: on Android and iOS the value is currently
+        /// stored and round-trips, but has no routing effect either.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown if set to null.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown if the list contains <see cref="AudioOutputKind.Unknown"/> or duplicates.
+        /// </exception>
+        public IReadOnlyList<AudioOutputKind> OutputPreference
+        {
+            get => _outputPreference.AsReadOnly();
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                var ranked = new List<AudioOutputKind>(value.Count);
+                foreach (var kind in value)
+                {
+                    if (kind == AudioOutputKind.Unknown)
+                        throw new ArgumentException(
+                            "OutputPreference cannot contain AudioOutputKind.Unknown", nameof(value));
+                    if (ranked.Contains(kind))
+                        throw new ArgumentException(
+                            $"OutputPreference contains {kind} more than once", nameof(value));
+                    ranked.Add(kind);
+                }
+
+                _outputPreference = ranked;
+                _routeController.ApplyOutputPreference(_outputPreference.AsReadOnly());
+            }
+        }
+
+        /// <summary>
+        /// Whether the loudspeaker is preferred over the earpiece for automatic routing.
+        ///
+        /// Precedence with <see cref="OutputPreference"/>: the list is the single source of
+        /// truth; this bool is convenience sugar that only rewrites the relative order of
+        /// <see cref="AudioOutputKind.Speaker"/> and <see cref="AudioOutputKind.Earpiece"/>
+        /// inside <see cref="OutputPreference"/>, and reading it reads their current
+        /// relative order. There is no separate speaker-preference state. Reading returns
+        /// true when Speaker ranks ahead of Earpiece (or Earpiece is absent), false when
+        /// Speaker is absent. Setting reorders the pair in place at the position of
+        /// whichever currently ranks first, inserting a missing kind next to the present
+        /// one (or appending both when neither is listed) so the value round-trips.
+        ///
+        /// Platform notes: on iOS, external devices (Bluetooth, wired) always take priority
+        /// over the built-in outputs, so this bool is the only part of the ranking with an
+        /// effect. On Android the full ranking applies. On desktop, output is selected
+        /// per device (<see cref="SelectOutput"/> / <see cref="SetPlayoutDevice(string)"/>)
+        /// and the ranking has no routing effect. The mobile routing backends are not
+        /// implemented yet in this version: on Android and iOS the value is currently
+        /// stored and round-trips, but has no routing effect either.
+        /// </summary>
+        public bool IsSpeakerOutputPreferred
+        {
+            get
+            {
+                var speaker = _outputPreference.IndexOf(AudioOutputKind.Speaker);
+                var earpiece = _outputPreference.IndexOf(AudioOutputKind.Earpiece);
+                if (speaker < 0) return false;
+                return earpiece < 0 || speaker < earpiece;
+            }
+            set
+            {
+                var first = value ? AudioOutputKind.Speaker : AudioOutputKind.Earpiece;
+                var second = value ? AudioOutputKind.Earpiece : AudioOutputKind.Speaker;
+
+                var reordered = new List<AudioOutputKind>(_outputPreference.Count + 2);
+                var pairInserted = false;
+                foreach (var kind in _outputPreference)
+                {
+                    if (kind == AudioOutputKind.Speaker || kind == AudioOutputKind.Earpiece)
+                    {
+                        if (!pairInserted)
+                        {
+                            reordered.Add(first);
+                            reordered.Add(second);
+                            pairInserted = true;
+                        }
+                        continue;
+                    }
+                    reordered.Add(kind);
+                }
+                if (!pairInserted)
+                {
+                    reordered.Add(first);
+                    reordered.Add(second);
+                }
+
+                _outputPreference = reordered;
+                _routeController.ApplyOutputPreference(_outputPreference.AsReadOnly());
+            }
+        }
+
+        /// <summary>
+        /// Routes audio output to the given device as a sticky override of the automatic
+        /// <see cref="OutputPreference"/> policy: the route stays on the device until
+        /// <see cref="ClearOutputOverride"/> is called. The device is matched against the
+        /// current <see cref="GetDevices"/> playout list by <see cref="AudioDevice.Guid"/>
+        /// when set, otherwise by index and name.
+        ///
+        /// Platform notes: on desktop this selects the device like
+        /// <see cref="SetPlayoutDevice(string)"/>. On Android and iOS the routing backends
+        /// are not implemented yet in this version and this method throws
+        /// <see cref="NotSupportedException"/>.
+        /// </summary>
+        /// <param name="device">A playout device from <see cref="GetDevices"/>.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if the device does not match any current playout device.
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// Thrown on Android and iOS, where no routing backend exists yet.
+        /// </exception>
+        public void SelectOutput(AudioDevice device)
+        {
+            var (_, playout) = GetDevices();
+            foreach (var candidate in playout)
+            {
+                var matches = !string.IsNullOrEmpty(device.Guid)
+                    ? candidate.Guid == device.Guid
+                    : candidate.Index == device.Index && candidate.Name == device.Name;
+                if (!matches) continue;
+
+                _routeController.SelectOutput(candidate);
+                return;
+            }
+
+            throw new ArgumentException(
+                $"Device '{device.Name}' (index {device.Index}, guid {device.Guid ?? "none"}) " +
+                "is not a current playout device", nameof(device));
+        }
+
+        /// <summary>
+        /// Clears the sticky override set by <see cref="SelectOutput"/> so the automatic
+        /// <see cref="OutputPreference"/> policy applies again.
+        ///
+        /// Platform notes: on desktop there is no automatic policy to fall back to yet, so
+        /// clearing keeps the currently selected device (no-op). On Android and iOS no
+        /// override can exist yet (<see cref="SelectOutput"/> throws), so this is a no-op
+        /// there as well.
+        /// </summary>
+        public void ClearOutputOverride()
+        {
+            _routeController.ClearOutputOverride();
+        }
+
+        /// <summary>
+        /// Raised when the set of available audio devices changes, with the current playout
+        /// and recording device lists. Raised on the Unity main thread.
+        ///
+        /// No implementation raises this event yet in this version: desktop hot-plug events
+        /// and the mobile routing backends that produce it are not implemented. Subscribing
+        /// and unsubscribing is safe at any time, including after <see cref="Dispose"/>.
+        /// </summary>
+        public event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged;
+
+        private void OnRouteControllerDevicesChanged(
+            IReadOnlyList<AudioDevice> playout, IReadOnlyList<AudioDevice> recording)
+        {
+            if (_disposed) return;
+
+            if (_syncContext != null && _syncContext != SynchronizationContext.Current)
+            {
+                _syncContext.Post(_ =>
+                {
+                    if (!_disposed)
+                        DevicesChanged?.Invoke(playout, recording);
+                }, null);
+                return;
+            }
+
+            DevicesChanged?.Invoke(playout, recording);
         }
 
         /// <summary>
@@ -363,6 +629,8 @@ namespace LiveKit
         public void Dispose()
         {
             if (_disposed) return;
+            _routeController.DevicesChanged -= OnRouteControllerDevicesChanged;
+            _routeController.Dispose();
             Handle.Dispose();
             _disposed = true;
             Utils.Debug("PlatformAudio disposed");

--- a/Runtime/Scripts/Audio/RouteController.cs
+++ b/Runtime/Scripts/Audio/RouteController.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+
+namespace LiveKit
+{
+    /// <summary>
+    /// Backend seam for audio output routing. <see cref="PlatformAudio"/> registers one
+    /// implementation per platform and forwards its public routing API
+    /// (<see cref="PlatformAudio.OutputPreference"/>, <see cref="PlatformAudio.SelectOutput"/>,
+    /// <see cref="PlatformAudio.ClearOutputOverride"/>, <see cref="PlatformAudio.GetDevices"/>,
+    /// <see cref="PlatformAudio.DevicesChanged"/>) through it, so the plumbing can be swapped
+    /// per platform — and later wholesale for an FFI-backed implementation — without changing
+    /// a public signature.
+    /// </summary>
+    internal interface IRouteController : IDisposable
+    {
+        /// <summary>Snapshot of the current recording and playout device lists.</summary>
+        (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevices();
+
+        /// <summary>Applies the ranked automatic output policy, most preferred first.</summary>
+        void ApplyOutputPreference(IReadOnlyList<AudioOutputKind> ranked);
+
+        /// <summary>
+        /// Routes output to the given device as a sticky override of the automatic policy.
+        /// The device has already been validated against the current playout snapshot.
+        /// </summary>
+        void SelectOutput(AudioDevice device);
+
+        /// <summary>Clears the sticky override so the automatic policy applies again.</summary>
+        void ClearOutputOverride();
+
+        /// <summary>
+        /// Raised when the available devices change, with the current (playout, recording)
+        /// lists. May be raised from any thread; <see cref="PlatformAudio"/> marshals it to
+        /// the Unity main thread before re-raising publicly.
+        /// </summary>
+        event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged;
+    }
+
+    /// <summary>
+    /// Desktop routing backend: wraps the FFI device enumeration and per-device GUID
+    /// selection. Ranked-kind policy is not implemented on desktop (output is chosen per
+    /// device), and no desktop hot-plug events exist yet, so <see cref="DevicesChanged"/>
+    /// is never raised.
+    /// </summary>
+    internal sealed class DesktopRouteController : IRouteController
+    {
+        private readonly PlatformAudio _owner;
+
+        public DesktopRouteController(PlatformAudio owner)
+        {
+            _owner = owner;
+        }
+
+        public (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevices()
+        {
+            return _owner.GetDevicesViaFfi();
+        }
+
+        public void ApplyOutputPreference(IReadOnlyList<AudioOutputKind> ranked)
+        {
+            // No routing effect on desktop: output is selected per device, not by kind.
+        }
+
+        public void SelectOutput(AudioDevice device)
+        {
+            if (!string.IsNullOrEmpty(device.Guid))
+                _owner.SetPlayoutDevice(device.Guid);
+            else
+                _owner.SetPlayoutDevice(device.Index);
+        }
+
+        public void ClearOutputOverride()
+        {
+            // No automatic policy to fall back to on desktop; the selected device stays.
+        }
+
+        public event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Placeholder backend for platforms whose routing implementation has not landed yet
+    /// (Android, iOS). Device snapshots still work through the FFI (a single placeholder
+    /// entry for the OS default input/output); the routing verbs throw or no-op as
+    /// documented on the public API.
+    /// </summary>
+    internal sealed class UnsupportedRouteController : IRouteController
+    {
+        private readonly PlatformAudio _owner;
+        private readonly string _platform;
+
+        public UnsupportedRouteController(PlatformAudio owner, string platform)
+        {
+            _owner = owner;
+            _platform = platform;
+        }
+
+        public (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevices()
+        {
+            return _owner.GetDevicesViaFfi();
+        }
+
+        public void ApplyOutputPreference(IReadOnlyList<AudioOutputKind> ranked)
+        {
+            // Stored by PlatformAudio; no routing effect until this platform's backend lands.
+        }
+
+        public void SelectOutput(AudioDevice device)
+        {
+            throw new NotSupportedException(
+                $"SelectOutput is not implemented on {_platform} yet");
+        }
+
+        public void ClearOutputOverride()
+        {
+            // No override can exist on this platform: SelectOutput throws.
+        }
+
+        public event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Runtime/Scripts/Audio/RouteController.cs.meta
+++ b/Runtime/Scripts/Audio/RouteController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a99955b361ca4e5aa765a7e6dfc9e73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/PlatformAudioTests.cs
+++ b/Tests/PlayMode/PlatformAudioTests.cs
@@ -103,6 +103,126 @@ namespace LiveKit.PlayModeTests
         }
 
         [UnityTest]
+        public IEnumerator OutputPreference_DefaultsAndRoundtrips()
+        {
+            using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            // Documented default ranking.
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    AudioOutputKind.Bluetooth,
+                    AudioOutputKind.WiredHeadset,
+                    AudioOutputKind.Speaker,
+                    AudioOutputKind.Earpiece,
+                },
+                platformAudio.OutputPreference);
+
+            // Set/get roundtrip preserves order and content.
+            var ranked = new[] { AudioOutputKind.Usb, AudioOutputKind.Speaker, AudioOutputKind.Bluetooth };
+            platformAudio.OutputPreference = ranked;
+            CollectionAssert.AreEqual(ranked, platformAudio.OutputPreference);
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator OutputPreference_RejectsInvalidLists()
+        {
+            using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            Assert.Throws<ArgumentNullException>(() => platformAudio.OutputPreference = null);
+            Assert.Throws<ArgumentException>(() =>
+                platformAudio.OutputPreference = new[] { AudioOutputKind.Unknown });
+            Assert.Throws<ArgumentException>(() =>
+                platformAudio.OutputPreference = new[] { AudioOutputKind.Speaker, AudioOutputKind.Speaker });
+
+            // A rejected assignment leaves the stored preference untouched.
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    AudioOutputKind.Bluetooth,
+                    AudioOutputKind.WiredHeadset,
+                    AudioOutputKind.Speaker,
+                    AudioOutputKind.Earpiece,
+                },
+                platformAudio.OutputPreference);
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator SpeakerPreference_BoolAndListOrderAreOneState()
+        {
+            using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            // Default ranking has Speaker ahead of Earpiece.
+            Assert.IsTrue(platformAudio.IsSpeakerOutputPreferred);
+
+            // Setting the bool rewrites the Speaker/Earpiece order inside the list.
+            platformAudio.IsSpeakerOutputPreferred = false;
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    AudioOutputKind.Bluetooth,
+                    AudioOutputKind.WiredHeadset,
+                    AudioOutputKind.Earpiece,
+                    AudioOutputKind.Speaker,
+                },
+                platformAudio.OutputPreference);
+            Assert.IsFalse(platformAudio.IsSpeakerOutputPreferred);
+
+            // Setting the list order flips the bool back — the list is the source of truth.
+            platformAudio.OutputPreference = new[]
+            {
+                AudioOutputKind.Speaker,
+                AudioOutputKind.Earpiece,
+                AudioOutputKind.Bluetooth,
+            };
+            Assert.IsTrue(platformAudio.IsSpeakerOutputPreferred);
+
+            // A missing kind is inserted next to the present one so the value round-trips.
+            platformAudio.OutputPreference = new[] { AudioOutputKind.Bluetooth, AudioOutputKind.Speaker };
+            platformAudio.IsSpeakerOutputPreferred = false;
+            CollectionAssert.AreEqual(
+                new[] { AudioOutputKind.Bluetooth, AudioOutputKind.Earpiece, AudioOutputKind.Speaker },
+                platformAudio.OutputPreference);
+            Assert.IsFalse(platformAudio.IsSpeakerOutputPreferred);
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator SelectOutput_BogusDevice_Throws()
+        {
+            using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            var bogus = new AudioDevice { Index = 9999, Name = "not-a-device", Guid = "no-such-guid" };
+            Assert.Throws<ArgumentException>(() => platformAudio.SelectOutput(bogus));
+
+            // Clearing is always safe, whether or not an override exists.
+            Assert.DoesNotThrow(() => platformAudio.ClearOutputOverride());
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator DevicesChanged_SubscribeUnsubscribe_SafeAcrossDispose()
+        {
+            var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> handler = (playout, recording) => { };
+            platformAudio.DevicesChanged += handler;
+            platformAudio.Dispose();
+
+            Assert.DoesNotThrow(() => platformAudio.DevicesChanged -= handler);
+            Assert.DoesNotThrow(() => platformAudio.DevicesChanged += handler);
+            Assert.DoesNotThrow(() => platformAudio.Dispose());
+
+            yield break;
+        }
+
+        [UnityTest]
         public IEnumerator StartThenStopRecording_DoesNotThrow()
         {
             using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();


### PR DESCRIPTION
### Background

First card of the platform-audio routing redesign's phase A (PAR-019): apps need a supported, cross-platform way to influence audio output routing (speaker vs. earpiece, ranked device-kind preferences, explicit device overrides, device-change notifications) instead of reaching into platform APIs themselves. This PR defines that public API surface on `PlatformAudio`, purely in C#, shaped identically to what the later FFI-backed implementation will expose — so nothing written against it is throwaway when the plumbing is swapped underneath.

### Changes

- Added `AudioOutputKind` enum (`Unknown`, `Earpiece`, `Speaker`, `WiredHeadset`, `Bluetooth`, `Usb`, `HearingAid`); numeric values mirror the planned FFI protocol enum one-to-one.
- `AudioDevice` gains `Kind` and `IsSelected` (documented as not yet populated — no backend reports them).
- New public API on `PlatformAudio`:
  - `OutputPreference` — ranked automatic output policy; default `Bluetooth > WiredHeadset > Speaker > Earpiece`.
  - `IsSpeakerOutputPreferred` — documented precedence rule: the bool is sugar that only rewrites the relative order of `Speaker`/`Earpiece` inside `OutputPreference`; the list is the single source of truth.
  - `SelectOutput(AudioDevice)` / `ClearOutputOverride()` — sticky override of the automatic policy; bogus devices throw `ArgumentException`.
  - `DevicesChanged` event (playout, recording), raised on the Unity main thread; safe to (un)subscribe across `Dispose`.
- Internal `IRouteController` backend seam with per-platform registration: `DesktopRouteController` wraps the existing FFI enumeration/GUID selection; `UnsupportedRouteController` covers Android/iOS until their phase-A backends land (documented throws/no-ops — no silent fake success anywhere).
- PlayMode tests: preference set/get roundtrip and validation, precedence rule in both directions (incl. missing-kind insertion), bogus `SelectOutput` throws, `DevicesChanged` subscribe/unsubscribe safe across dispose.
