### PR TITLE
Add iOS session states, speaker preference, and route events (PAR-021)

### DIFF
--- a/Runtime/Plugins/iOS/LiveKitAudioSession.mm
+++ b/Runtime/Plugins/iOS/LiveKitAudioSession.mm
@@ -218,9 +218,20 @@ static void LiveKit_MirrorWebRTCConfiguration(NSString* mode,
 /// Applies the config derived from (s_sessionState, s_speakerPreferred) to the
 /// session and mirrors it into the WebRTC snapshot. Logs expected vs. actual so
 /// device tests can see who won when something else reconfigures the session.
-static void LiveKit_ApplySessionConfig(NSString* reason) {
+///
+/// rebuildAudioUnitOnModeChange: the ADM does not rebuild its VPIO unit on a
+/// route change that keeps the hardware sample rate (HandleValidRouteChange ->
+/// HandleSampleRateChange no-ops when the audio parameters are intact), so a
+/// live mode switch leaves the unit calibrated for the previous route --
+/// device-observed as an attenuated loudspeaker after an earpiece -> speaker
+/// toggle. Passing YES cycles isAudioEnabled after a mode change to force a
+/// clean rebuild against the new route, at the cost of a brief audio gap.
+/// Callers that handle the rebuild themselves (foreground recovery) or run
+/// before the unit exists (configure) pass NO.
+static void LiveKit_ApplySessionConfig(NSString* reason, BOOL rebuildAudioUnitOnModeChange) {
     NSString* mode = LiveKit_DesiredMode();
     AVAudioSessionCategoryOptions options = LiveKit_DesiredOptions();
+    BOOL modeChanged = ![[AVAudioSession sharedInstance].mode isEqualToString:mode];
 
     id<LiveKitRTCAudioSession> rtc = LiveKit_RTCSession();
     NSError* error = nil;
@@ -252,6 +263,13 @@ static void LiveKit_ApplySessionConfig(NSString* reason) {
            " -> actual category=%@ mode=%@ options=%lu",
           reason, s_sessionState, s_speakerPreferred, mode, (unsigned long)options,
           current.category, current.mode, (unsigned long)current.categoryOptions);
+
+    if (rebuildAudioUnitOnModeChange && modeChanged && s_audioDesired && rtc != nil) {
+        rtc.isAudioEnabled = NO;
+        rtc.isAudioEnabled = YES;
+        NSLog(@"LiveKit: cycled isAudioEnabled to rebuild the audio unit after mode change (%@)",
+              reason);
+    }
 }
 
 /// Re-applies the current state's config and reactivates the session, then
@@ -276,7 +294,7 @@ static void LiveKit_ScheduleSessionRecovery() {
         NSLog(@"LiveKit: foreground recovery; session before re-assert: category=%@ mode=%@ options=%lu",
               session.category, session.mode, (unsigned long)session.categoryOptions);
 
-        LiveKit_ApplySessionConfig(@"foreground recovery");
+        LiveKit_ApplySessionConfig(@"foreground recovery", NO);
 
         // Reactivate directly on AVAudioSession: the OS deactivated the hardware
         // session during the interruption, but RTCAudioSession's activation
@@ -415,7 +433,7 @@ void LiveKit_ConfigureAudioSessionForVoIP() {
         rtc.useManualAudio = YES;
     }
 
-    LiveKit_ApplySessionConfig(@"configure");
+    LiveKit_ApplySessionConfig(@"configure", NO);
 
     if (rtc == nil) {
         // RTCAudioSession unavailable: activate AVAudioSession directly (legacy).
@@ -482,7 +500,7 @@ void LiveKit_SetSpeakerPreferred(bool preferred) {
     }
     s_speakerPreferred = value;
     if (s_liveKitConfigured) {
-        LiveKit_ApplySessionConfig(@"speaker preference");
+        LiveKit_ApplySessionConfig(@"speaker preference", YES);
     }
 }
 
@@ -499,7 +517,7 @@ void LiveKit_SetSessionState(int state) {
     }
     s_sessionState = state;
     if (s_liveKitConfigured) {
-        LiveKit_ApplySessionConfig(@"session state");
+        LiveKit_ApplySessionConfig(@"session state", YES);
     }
 }
 

--- a/Runtime/Plugins/iOS/LiveKitAudioSession.mm
+++ b/Runtime/Plugins/iOS/LiveKitAudioSession.mm
@@ -17,6 +17,9 @@
 #import <AVFoundation/AVFoundation.h>
 #import <UIKit/UIKit.h>
 
+#include <stdlib.h>
+#include <string.h>
+
 // This plugin coordinates the single shared AVAudioSession with WebRTC's iOS
 // Audio Device Module (ADM). WebRTC ships an RTCAudioSession proxy that, left in
 // its default "automatic" mode, reconfigures the category/route and *deactivates*
@@ -30,11 +33,14 @@
 //   * We hold exactly one permanent activation (setActive:YES). Because
 //     RTCAudioSession ref-counts activation, WebRTC's per-call setActive:YES/NO
 //     only cycles the count and never actually deactivates the hardware session.
-//   * We set the category once (PlayAndRecord + VideoChat mode). VideoChat routes
-//     to the loudspeaker by default (while still honoring connected wired/Bluetooth
-//     headphones), so WebRTC re-applying its own config keeps output on the speaker
-//     instead of the earpiece. We deliberately do NOT force the speaker via
-//     overrideOutputAudioPort, which would override plugged-in headphones.
+//   * The category/mode/options are derived from a session STATE machine driven
+//     from C# (PlatformAudio knows the call's recording state) plus a
+//     speaker-vs-earpiece preference (see the table below). Every apply is also
+//     mirrored into WebRTC's RTCAudioSessionConfiguration snapshot so the ADM
+//     re-applies the same config on its own restarts.
+//   * The speaker preference is expressed via the session MODE only (VideoChat
+//     routes to the loudspeaker by default, VoiceChat to the receiver), never via
+//     overrideOutputAudioPort, so connected wired/Bluetooth devices always win.
 //   * The VPIO voice-processing unit (hardware AEC/AGC/NS) is gated by
 //     isAudioEnabled. It defaults to YES so call audio works out of the box (the
 //     unit still only initializes once a call actually has an audio track, so
@@ -46,8 +52,28 @@
 //     with no retry -- and Unity/FMOD restarts *its* audio around the same moment,
 //     reconfiguring the shared session (observed with Unity 6). Whoever loses that
 //     race stays broken, so we observe foreground/interruption-end ourselves and,
-//     after Unity's restart has settled, re-assert our config and cycle
-//     isAudioEnabled to force a clean rebuild of the audio unit.
+//     after Unity's restart has settled, re-assert the current state's config and
+//     cycle isAudioEnabled to force a clean rebuild of the audio unit.
+//   * Route changes (headset plug/unplug, Bluetooth connect, mode switches) are
+//     observed via AVAudioSessionRouteChangeNotification and forwarded to C#
+//     through a registered callback so the SDK can raise its DevicesChanged event.
+//
+// Session state table (state is set from C# via LiveKit_SetSessionState):
+//
+//   state          category       mode                     options
+//   0 idle         PlayAndRecord  Default                  BT | A2DP | MixWithOthers
+//                                                          | DefaultToSpeaker*
+//   1 playout-only PlayAndRecord  Default                  same as idle
+//   2 recording    PlayAndRecord  VideoChat (speaker) /    BT | A2DP
+//                                 VoiceChat (earpiece)
+//
+//   *DefaultToSpeaker only while the speaker is preferred. In the recording state
+//    the speaker preference is carried by the mode alone. Idle and playout-only
+//    share a config: PlayAndRecord stays because the ADM initializes its VPIO unit
+//    with input disabled for playout-only (InitPlayOrRecord(false)) but nothing
+//    guarantees VPIO under the Playback category; mode Default + MixWithOthers is
+//    the music-friendliest config the ADM demonstrably supports. The states stay
+//    distinct so the mapping can diverge without touching the C# driver.
 //
 // RTCAudioSession lives inside the statically-linked liblivekit_ffi; we reach it
 // dynamically via NSClassFromString + a protocol-typed id so this file never
@@ -67,6 +93,23 @@
             options:(AVAudioSessionCategoryOptions)options
               error:(NSError**)outError;
 @end
+
+/// Minimal subset of WebRTC's RTCAudioSessionConfiguration (the snapshot the ADM
+/// re-applies on its own restarts), messaged dynamically like RTCAudioSession.
+@protocol LiveKitRTCAudioSessionConfiguration <NSObject>
+@property(nonatomic, strong) NSString* category;
+@property(nonatomic, assign) AVAudioSessionCategoryOptions categoryOptions;
+@property(nonatomic, strong) NSString* mode;
+@end
+
+/// Session states, mirroring PlatformAudio's driver in C#. Do not renumber.
+enum {
+    kLiveKitSessionStateIdle = 0,
+    kLiveKitSessionStatePlayoutOnly = 1,
+    kLiveKitSessionStateRecording = 2,
+};
+
+typedef void (*LiveKitRouteChangeCallback)(void);
 
 // Tracks whether *we* currently hold the one app-owned activation, so we add and
 // release it exactly once regardless of how many times configure/restore run.
@@ -91,10 +134,27 @@ static BOOL s_audioDesired = NO;
 // on foreground) into one delayed pass.
 static BOOL s_recoveryPending = NO;
 
-static const AVAudioSessionCategoryOptions kLiveKitCategoryOptions =
-    AVAudioSessionCategoryOptionDefaultToSpeaker |
+// The state machine inputs (see the table above). The defaults match what a fresh
+// PlatformAudio pushes right after construction, so the config applied by
+// configure is already the one the C# driver expects.
+static int s_sessionState = kLiveKitSessionStatePlayoutOnly;
+static BOOL s_speakerPreferred = YES;
+
+// Invoked (on the main queue) whenever the audio route changes, so the C# side
+// can re-query the route and raise DevicesChanged.
+static LiveKitRouteChangeCallback s_routeChangeCallback = NULL;
+
+// AllowBluetooth was renamed AllowBluetoothHFP in the iOS 26 SDK; same guard the
+// WebRTC fork uses. The speaker preference never rides on these options.
+#if defined(__IPHONE_26_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_26_0
+static const AVAudioSessionCategoryOptions kLiveKitBluetoothOptions =
+    AVAudioSessionCategoryOptionAllowBluetoothHFP |
+    AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+#else
+static const AVAudioSessionCategoryOptions kLiveKitBluetoothOptions =
     AVAudioSessionCategoryOptionAllowBluetooth |
     AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+#endif
 
 /// Returns WebRTC's shared RTCAudioSession if it's present in the linked binary,
 /// or nil if the class can't be found (in which case callers use AVAudioSession).
@@ -109,7 +169,92 @@ static id<LiveKitRTCAudioSession> LiveKit_RTCSession() {
 #pragma clang diagnostic pop
 }
 
-/// Re-applies LiveKit's category/mode/options and reactivates the session, then
+static NSString* LiveKit_DesiredMode() {
+    if (s_sessionState == kLiveKitSessionStateRecording) {
+        return s_speakerPreferred ? AVAudioSessionModeVideoChat
+                                  : AVAudioSessionModeVoiceChat;
+    }
+    return AVAudioSessionModeDefault;
+}
+
+static AVAudioSessionCategoryOptions LiveKit_DesiredOptions() {
+    AVAudioSessionCategoryOptions options = kLiveKitBluetoothOptions;
+    if (s_sessionState != kLiveKitSessionStateRecording) {
+        options |= AVAudioSessionCategoryOptionMixWithOthers;
+        // Mode Default routes PlayAndRecord to the receiver; outside a call there
+        // is no mode that both prefers the speaker and leaves music processing
+        // alone, so here -- and only here -- the preference rides on an option.
+        if (s_speakerPreferred) {
+            options |= AVAudioSessionCategoryOptionDefaultToSpeaker;
+        }
+    }
+    return options;
+}
+
+/// Mirrors our category/mode/options into WebRTC's RTCAudioSessionConfiguration
+/// snapshot so the ADM re-applies the same config whenever it (re)configures the
+/// session itself (audio unit init, interruption recovery).
+static void LiveKit_MirrorWebRTCConfiguration(NSString* mode,
+                                              AVAudioSessionCategoryOptions options) {
+    Class cls = NSClassFromString(@"RTCAudioSessionConfiguration");
+    if (!cls || ![cls respondsToSelector:@selector(webRTCConfiguration)] ||
+        ![cls respondsToSelector:@selector(setWebRTCConfiguration:)]) {
+        return;
+    }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    id<LiveKitRTCAudioSessionConfiguration> config =
+        (id<LiveKitRTCAudioSessionConfiguration>)[cls performSelector:@selector(webRTCConfiguration)];
+    if (config == nil) {
+        return;
+    }
+    config.category = AVAudioSessionCategoryPlayAndRecord;
+    config.mode = mode;
+    config.categoryOptions = options;
+    [cls performSelector:@selector(setWebRTCConfiguration:) withObject:config];
+#pragma clang diagnostic pop
+}
+
+/// Applies the config derived from (s_sessionState, s_speakerPreferred) to the
+/// session and mirrors it into the WebRTC snapshot. Logs expected vs. actual so
+/// device tests can see who won when something else reconfigures the session.
+static void LiveKit_ApplySessionConfig(NSString* reason) {
+    NSString* mode = LiveKit_DesiredMode();
+    AVAudioSessionCategoryOptions options = LiveKit_DesiredOptions();
+
+    id<LiveKitRTCAudioSession> rtc = LiveKit_RTCSession();
+    NSError* error = nil;
+    if (rtc != nil) {
+        [rtc lockForConfiguration];
+        if (![rtc setCategory:AVAudioSessionCategoryPlayAndRecord
+                         mode:mode
+                      options:options
+                        error:&error] || error) {
+            NSLog(@"LiveKit: failed to apply session config (%@): %@",
+                  reason, error.localizedDescription);
+        }
+        [rtc unlockForConfiguration];
+    } else {
+        AVAudioSession* session = [AVAudioSession sharedInstance];
+        if (![session setCategory:AVAudioSessionCategoryPlayAndRecord
+                             mode:mode
+                          options:options
+                            error:&error] || error) {
+            NSLog(@"LiveKit: failed to apply session config (%@): %@",
+                  reason, error.localizedDescription);
+        }
+    }
+
+    LiveKit_MirrorWebRTCConfiguration(mode, options);
+
+    AVAudioSession* current = [AVAudioSession sharedInstance];
+    NSLog(@"LiveKit: session config (%@): state=%d speakerPreferred=%d expected mode=%@ options=%lu"
+           " -> actual category=%@ mode=%@ options=%lu",
+          reason, s_sessionState, s_speakerPreferred, mode, (unsigned long)options,
+          current.category, current.mode, (unsigned long)current.categoryOptions);
+}
+
+/// Re-applies the current state's config and reactivates the session, then
 /// cycles isAudioEnabled to force WebRTC to rebuild its VPIO audio unit. Runs on
 /// a delay so it lands after Unity/FMOD's own foreground audio restart (which is
 /// itself delayed and can reconfigure the shared session underneath WebRTC's
@@ -131,31 +276,13 @@ static void LiveKit_ScheduleSessionRecovery() {
         NSLog(@"LiveKit: foreground recovery; session before re-assert: category=%@ mode=%@ options=%lu",
               session.category, session.mode, (unsigned long)session.categoryOptions);
 
-        id<LiveKitRTCAudioSession> rtc = LiveKit_RTCSession();
-        NSError* error = nil;
-        if (rtc != nil) {
-            [rtc lockForConfiguration];
-            if (![rtc setCategory:AVAudioSessionCategoryPlayAndRecord
-                             mode:AVAudioSessionModeVideoChat
-                          options:kLiveKitCategoryOptions
-                            error:&error] || error) {
-                NSLog(@"LiveKit: recovery failed to re-set category: %@", error.localizedDescription);
-            }
-            [rtc unlockForConfiguration];
-        } else {
-            if (![session setCategory:AVAudioSessionCategoryPlayAndRecord
-                                 mode:AVAudioSessionModeVideoChat
-                              options:kLiveKitCategoryOptions
-                                error:&error] || error) {
-                NSLog(@"LiveKit: recovery failed to re-set category: %@", error.localizedDescription);
-            }
-        }
+        LiveKit_ApplySessionConfig(@"foreground recovery");
 
         // Reactivate directly on AVAudioSession: the OS deactivated the hardware
         // session during the interruption, but RTCAudioSession's activation
         // ref-count still includes our held activation, so reactivating through
         // the proxy would double-count it.
-        error = nil;
+        NSError* error = nil;
         if (![session setActive:YES error:&error] || error) {
             NSLog(@"LiveKit: recovery failed to reactivate session: %@", error.localizedDescription);
         }
@@ -164,6 +291,7 @@ static void LiveKit_ScheduleSessionRecovery() {
         // session (WebRTC's own foreground restart may have failed, or been undone
         // by Unity's). Harmless when no call audio is active: with playout and
         // recording uninitialized WebRTC ignores the change.
+        id<LiveKitRTCAudioSession> rtc = LiveKit_RTCSession();
         if (rtc != nil && s_audioDesired) {
             rtc.isAudioEnabled = NO;
             rtc.isAudioEnabled = YES;
@@ -174,9 +302,9 @@ static void LiveKit_ScheduleSessionRecovery() {
     });
 }
 
-/// Registers app-lifetime observers that trigger session recovery when the app
-/// returns to the foreground or an audio interruption ends. Registered once on
-/// first configure; the handlers no-op while LiveKit is not configured.
+/// Registers app-lifetime observers for foreground/interruption recovery and for
+/// route-change forwarding. Registered once on first configure; the handlers
+/// no-op while LiveKit is not configured.
 static void LiveKit_RegisterLifecycleObserversIfNeeded() {
     static BOOL s_observersRegistered = NO;
     if (s_observersRegistered) {
@@ -200,6 +328,27 @@ static void LiveKit_RegisterLifecycleObserversIfNeeded() {
             LiveKit_ScheduleSessionRecovery();
         }
     }];
+    [center addObserverForName:AVAudioSessionRouteChangeNotification
+                        object:nil
+                         queue:[NSOperationQueue mainQueue]
+                    usingBlock:^(NSNotification* note) {
+        if (!s_liveKitConfigured) {
+            return;
+        }
+        NSNumber* reason = note.userInfo[AVAudioSessionRouteChangeReasonKey];
+        NSMutableArray<NSString*>* outputs = [NSMutableArray array];
+        for (AVAudioSessionPortDescription* port in
+             [AVAudioSession sharedInstance].currentRoute.outputs) {
+            [outputs addObject:[NSString stringWithFormat:@"%@ (%@)", port.portName, port.portType]];
+        }
+        NSLog(@"LiveKit: route changed (reason=%lu) outputs=%@",
+              (unsigned long)reason.unsignedIntegerValue,
+              [outputs componentsJoinedByString:@", "]);
+        LiveKitRouteChangeCallback callback = s_routeChangeCallback;
+        if (callback != NULL) {
+            callback();
+        }
+    }];
 }
 
 /// Captures the current audio session category/mode/options exactly once, before
@@ -219,15 +368,31 @@ static void LiveKit_CacheSessionStateIfNeeded() {
           s_cachedCategory, s_cachedMode, (unsigned long)s_cachedCategoryOptions);
 }
 
+/// Maps an AVAudioSessionPort type to the C# AudioOutputKind numbering
+/// (Unknown=0, Earpiece=1, Speaker=2, WiredHeadset=3, Bluetooth=4, Usb=5,
+/// HearingAid=6). Do not renumber. AVAudioSession has no dedicated hearing-aid
+/// port type, so 6 is never produced here; AirPlay/HDMI/CarAudio and other
+/// unroutable-by-us ports map to Unknown.
+static int LiveKit_OutputKindForPortType(NSString* portType) {
+    if ([portType isEqualToString:AVAudioSessionPortBuiltInReceiver]) return 1;
+    if ([portType isEqualToString:AVAudioSessionPortBuiltInSpeaker]) return 2;
+    if ([portType isEqualToString:AVAudioSessionPortHeadphones]) return 3;
+    if ([portType isEqualToString:AVAudioSessionPortBluetoothA2DP] ||
+        [portType isEqualToString:AVAudioSessionPortBluetoothHFP] ||
+        [portType isEqualToString:AVAudioSessionPortBluetoothLE]) return 4;
+    if ([portType isEqualToString:AVAudioSessionPortUSBAudio]) return 5;
+    return 0;
+}
+
 extern "C" {
 
 /// Configures the iOS audio session for VoIP/WebRTC use and takes app ownership
 /// of the shared AVAudioSession.
 ///
-/// This sets AVAudioSessionCategoryPlayAndRecord with VideoChat mode (which routes
-/// to the loudspeaker by default and enables the VPIO Voice Processing IO unit for
-/// hardware AEC/AGC/NS), puts RTCAudioSession into manual mode, and holds a single
-/// permanent activation so WebRTC never deactivates the session on its own.
+/// This applies the config for the current session state (playout-only for a
+/// fresh PlatformAudio; see the state table at the top of this file), puts
+/// RTCAudioSession into manual mode, and holds a single permanent activation so
+/// WebRTC never deactivates the session on its own.
 ///
 /// Call this before creating PlatformAudio. Call audio is enabled by default, so
 /// no further call is required for it to work; use LiveKit_SetAudioEnabled(false)
@@ -242,52 +407,41 @@ void LiveKit_ConfigureAudioSessionForVoIP() {
 
     id<LiveKitRTCAudioSession> rtc = LiveKit_RTCSession();
 
+    // Manual mode: WebRTC won't activate/deactivate the session on its own, and
+    // won't initialize the VPIO unit until we grant permission via isAudioEnabled
+    // (set below). This is what lets us own activation and gate the unit. Set
+    // before the first apply so the ADM never races the initial configuration.
+    if (rtc != nil) {
+        rtc.useManualAudio = YES;
+    }
+
+    LiveKit_ApplySessionConfig(@"configure");
+
     if (rtc == nil) {
-        // RTCAudioSession unavailable: configure AVAudioSession directly (legacy).
+        // RTCAudioSession unavailable: activate AVAudioSession directly (legacy).
         AVAudioSession* session = [AVAudioSession sharedInstance];
         NSError* error = nil;
-        if (![session setCategory:AVAudioSessionCategoryPlayAndRecord
-                             mode:AVAudioSessionModeVideoChat
-                          options:kLiveKitCategoryOptions
-                            error:&error] || error) {
-            NSLog(@"LiveKit: Failed to configure audio session: %@", error.localizedDescription);
-            return;
-        }
         if (![session setActive:YES error:&error] || error) {
             NSLog(@"LiveKit: Failed to activate audio session: %@", error.localizedDescription);
             return;
         }
-        NSLog(@"LiveKit: Audio session configured (AVAudioSession fallback, VideoChat)");
+        NSLog(@"LiveKit: Audio session configured (AVAudioSession fallback)");
         return;
-    }
-
-    // Manual mode: WebRTC won't activate/deactivate the session on its own, and
-    // won't initialize the VPIO unit until we grant permission via isAudioEnabled
-    // (set below). This is what lets us own activation and gate the unit.
-    rtc.useManualAudio = YES;
-
-    [rtc lockForConfiguration];
-    NSError* error = nil;
-    if (![rtc setCategory:AVAudioSessionCategoryPlayAndRecord
-                     mode:AVAudioSessionModeVideoChat
-                  options:kLiveKitCategoryOptions
-                    error:&error] || error) {
-        NSLog(@"LiveKit: Failed to set audio category: %@", error.localizedDescription);
     }
 
     // Hold exactly one app-owned activation. RTCAudioSession ref-counts activation,
     // so WebRTC's balanced setActive:YES/NO during a call never drops the real
     // session below active while we hold this.
     if (!s_liveKitHoldsActivation) {
-        error = nil;
+        [rtc lockForConfiguration];
+        NSError* error = nil;
         if ([rtc setActive:YES error:&error] && !error) {
             s_liveKitHoldsActivation = YES;
         } else {
             NSLog(@"LiveKit: Failed to activate audio session: %@", error.localizedDescription);
         }
+        [rtc unlockForConfiguration];
     }
-
-    [rtc unlockForConfiguration];
 
     // Grant WebRTC permission to initialize its audio unit by default so call audio
     // works without an explicit LiveKit_SetAudioEnabled(true). The unit is only
@@ -296,7 +450,7 @@ void LiveKit_ConfigureAudioSessionForVoIP() {
     // LiveKit_SetAudioEnabled(false).
     rtc.isAudioEnabled = YES;
 
-    NSLog(@"LiveKit: Audio session configured for VoIP (PlayAndRecord + VideoChat, manual mode, activationCount=%d)",
+    NSLog(@"LiveKit: Audio session configured for VoIP (manual mode, activationCount=%d)",
           rtc.activationCount);
 }
 
@@ -317,6 +471,65 @@ void LiveKit_SetAudioEnabled(bool enabled) {
     NSLog(@"LiveKit: isAudioEnabled=%@ (activationCount=%d)", enabled ? @"YES" : @"NO", rtc.activationCount);
 }
 
+/// Sets whether the loudspeaker is preferred over the earpiece for the built-in
+/// outputs and live-applies the resulting config (see the state table). External
+/// devices (wired, Bluetooth) always take priority over both; this only decides
+/// where audio goes when no external device is connected.
+void LiveKit_SetSpeakerPreferred(bool preferred) {
+    BOOL value = preferred ? YES : NO;
+    if (s_speakerPreferred == value) {
+        return;
+    }
+    s_speakerPreferred = value;
+    if (s_liveKitConfigured) {
+        LiveKit_ApplySessionConfig(@"speaker preference");
+    }
+}
+
+/// Sets the session state (0 idle, 1 playout-only, 2 recording; see the state
+/// table) and live-applies the resulting config. Driven from C#: PlatformAudio
+/// knows whether recording is active and whether call audio is wanted.
+void LiveKit_SetSessionState(int state) {
+    if (state < kLiveKitSessionStateIdle || state > kLiveKitSessionStateRecording) {
+        NSLog(@"LiveKit: ignoring unknown session state %d", state);
+        return;
+    }
+    if (s_sessionState == state) {
+        return;
+    }
+    s_sessionState = state;
+    if (s_liveKitConfigured) {
+        LiveKit_ApplySessionConfig(@"session state");
+    }
+}
+
+/// Registers (or clears, with NULL) the callback invoked on the main queue
+/// whenever the audio route changes. The callback carries no payload; the C#
+/// side re-queries LiveKit_GetCurrentOutputRoutes.
+void LiveKit_SetRouteChangeCallback(LiveKitRouteChangeCallback callback) {
+    s_routeChangeCallback = callback;
+}
+
+/// Returns the current output route as newline-separated "kind\tname\tuid"
+/// entries (kind per LiveKit_OutputKindForPortType). The caller must release the
+/// returned buffer with LiveKit_FreeRouteString.
+char* LiveKit_GetCurrentOutputRoutes() {
+    NSMutableString* result = [NSMutableString string];
+    for (AVAudioSessionPortDescription* port in
+         [AVAudioSession sharedInstance].currentRoute.outputs) {
+        [result appendFormat:@"%d\t%@\t%@\n",
+                             LiveKit_OutputKindForPortType(port.portType),
+                             port.portName ?: @"",
+                             port.UID ?: @""];
+    }
+    return strdup(result.UTF8String);
+}
+
+/// Frees a buffer returned by LiveKit_GetCurrentOutputRoutes.
+void LiveKit_FreeRouteString(char* str) {
+    free(str);
+}
+
 /// Restores the audio session Unity had before LiveKit touched it (or the ambient
 /// category if LiveKit never configured it), relinquishes the app-owned activation
 /// and manual mode, and reactivates the session so Unity audio output resumes.
@@ -325,6 +538,10 @@ void LiveKit_RestoreDefaultAudioSession() {
     // Stand down the foreground-recovery observers before touching the session.
     s_liveKitConfigured = NO;
     s_audioDesired = NO;
+    // Reset the state machine to the defaults a fresh PlatformAudio expects, so a
+    // later reconfigure starts from the same config it will be driven to.
+    s_sessionState = kLiveKitSessionStatePlayoutOnly;
+    s_speakerPreferred = YES;
 
     id<LiveKitRTCAudioSession> rtc = LiveKit_RTCSession();
 

--- a/Runtime/Scripts/Audio/IosRouteController.cs
+++ b/Runtime/Scripts/Audio/IosRouteController.cs
@@ -1,0 +1,216 @@
+#if UNITY_IOS && !UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using LiveKit.Internal;
+
+namespace LiveKit
+{
+    /// <summary>
+    /// iOS routing backend over the LiveKitAudioSession.mm plugin. The OS owns output
+    /// route selection on iOS, so this backend does not pick devices: it reduces
+    /// <see cref="PlatformAudio.OutputPreference"/> to the speaker-vs-earpiece relative
+    /// order (applied as the audio session mode by the plugin; external devices always
+    /// take priority over both built-ins), reports the session's current output route
+    /// as the playout device list, and raises <see cref="DevicesChanged"/> from the
+    /// plugin's route-change observation. <see cref="SelectOutput"/> throws: apps that
+    /// want explicit device picking should present the system route picker
+    /// (AVRoutePickerView).
+    ///
+    /// All plugin P/Invoke for route observation stays inside this class; the session
+    /// state machine itself is driven by <see cref="PlatformAudio"/> (which knows the
+    /// recording state) through <see cref="IOSAudioSessionHelper"/>.
+    /// </summary>
+    internal sealed class IosRouteController : IRouteController
+    {
+        private delegate void RouteChangeDelegate();
+
+        [DllImport("__Internal")]
+        private static extern void LiveKit_SetRouteChangeCallback(RouteChangeDelegate callback);
+
+        [DllImport("__Internal")]
+        private static extern void LiveKit_SetSpeakerPreferred([MarshalAs(UnmanagedType.I1)] bool preferred);
+
+        [DllImport("__Internal")]
+        private static extern IntPtr LiveKit_GetCurrentOutputRoutes();
+
+        [DllImport("__Internal")]
+        private static extern void LiveKit_FreeRouteString(IntPtr routes);
+
+        // The native callback slot is registered once for the app lifetime (matching
+        // the plugin's app-lifetime notification observers) and fans out to the live
+        // controllers; keeping the delegate in a static field pins it for the native
+        // side. Instances add and remove themselves under StaticGate.
+        private static readonly object StaticGate = new object();
+        private static readonly List<IosRouteController> LiveControllers = new List<IosRouteController>();
+        private static readonly RouteChangeDelegate NativeRouteChanged = OnNativeRouteChanged;
+        private static bool _callbackRegistered;
+
+        private readonly object _gate = new object();
+        // The FFI recording list (a single placeholder for the OS default input),
+        // captured once: route changes never affect it and re-querying the FFI from
+        // the route callback would be wasted work.
+        private readonly List<AudioDevice> _recordingSnapshot;
+        private string _lastSignature;
+        private bool _disposed;
+
+        public event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged;
+
+        internal IosRouteController(PlatformAudio owner, IReadOnlyList<AudioOutputKind> initialPreference)
+        {
+            _recordingSnapshot = owner.GetDevicesViaFfi().Recording;
+
+            ApplyOutputPreference(initialPreference);
+            _lastSignature = Signature(QueryCurrentOutputs());
+
+            lock (StaticGate)
+            {
+                LiveControllers.Add(this);
+                if (!_callbackRegistered)
+                {
+                    LiveKit_SetRouteChangeCallback(NativeRouteChanged);
+                    _callbackRegistered = true;
+                }
+            }
+        }
+
+        public (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevices()
+        {
+            return (new List<AudioDevice>(_recordingSnapshot), QueryCurrentOutputs());
+        }
+
+        public void ApplyOutputPreference(IReadOnlyList<AudioOutputKind> ranked)
+        {
+            // Reduce the ranked list per the PAR-019 precedence rule: the only part of
+            // the ranking iOS can express is whether Speaker outranks Earpiece.
+            var speaker = -1;
+            var earpiece = -1;
+            for (var i = 0; i < ranked.Count; i++)
+            {
+                if (ranked[i] == AudioOutputKind.Speaker) speaker = i;
+                else if (ranked[i] == AudioOutputKind.Earpiece) earpiece = i;
+            }
+            var speakerPreferred = speaker >= 0 && (earpiece < 0 || speaker < earpiece);
+            LiveKit_SetSpeakerPreferred(speakerPreferred);
+        }
+
+        public void SelectOutput(AudioDevice device)
+        {
+            throw new NotSupportedException(
+                "SelectOutput is not supported on iOS: the OS owns output route selection. " +
+                "Present the system route picker (AVRoutePickerView) instead, or use " +
+                "OutputPreference / IsSpeakerOutputPreferred for the built-in outputs.");
+        }
+
+        public void ClearOutputOverride()
+        {
+            // No override can exist on iOS: SelectOutput throws.
+        }
+
+        public void Dispose()
+        {
+            lock (StaticGate)
+            {
+                LiveControllers.Remove(this);
+            }
+            lock (_gate)
+            {
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Native route-change entry point, invoked by the plugin on the iOS main
+        /// queue (not the Unity main thread; <see cref="PlatformAudio"/> marshals the
+        /// public event).
+        /// </summary>
+        [AOT.MonoPInvokeCallback(typeof(RouteChangeDelegate))]
+        private static void OnNativeRouteChanged()
+        {
+            IosRouteController[] controllers;
+            lock (StaticGate)
+            {
+                controllers = LiveControllers.ToArray();
+            }
+            foreach (var controller in controllers)
+                controller.HandleRouteChanged();
+        }
+
+        private void HandleRouteChanged()
+        {
+            List<AudioDevice> playout;
+            lock (_gate)
+            {
+                if (_disposed) return;
+
+                playout = QueryCurrentOutputs();
+                var signature = Signature(playout);
+                if (signature == _lastSignature) return;
+                _lastSignature = signature;
+            }
+
+            DevicesChanged?.Invoke(playout, new List<AudioDevice>(_recordingSnapshot));
+        }
+
+        /// <summary>
+        /// The current output route reported by the audio session. On iOS this is the
+        /// active route (usually one device), not an enumeration of every reachable
+        /// device — AVAudioSession exposes no such list for outputs.
+        /// </summary>
+        private static List<AudioDevice> QueryCurrentOutputs()
+        {
+            var devices = new List<AudioDevice>();
+
+            var routesPtr = LiveKit_GetCurrentOutputRoutes();
+            if (routesPtr == IntPtr.Zero) return devices;
+
+            string routes;
+            try
+            {
+                routes = Marshal.PtrToStringUTF8(routesPtr);
+            }
+            finally
+            {
+                LiveKit_FreeRouteString(routesPtr);
+            }
+            if (string.IsNullOrEmpty(routes)) return devices;
+
+            foreach (var line in routes.Split('\n'))
+            {
+                if (line.Length == 0) continue;
+                var fields = line.Split('\t');
+                if (fields.Length != 3)
+                {
+                    Utils.Warning($"IosRouteController: malformed route entry '{line}'");
+                    continue;
+                }
+
+                var kind = int.TryParse(fields[0], out var rawKind)
+                           && Enum.IsDefined(typeof(AudioOutputKind), rawKind)
+                    ? (AudioOutputKind)rawKind
+                    : AudioOutputKind.Unknown;
+                devices.Add(new AudioDevice
+                {
+                    Index = (uint)devices.Count,
+                    Name = fields[1],
+                    Guid = fields[2],
+                    Kind = kind,
+                    // Everything in the current route is live output by definition.
+                    IsSelected = true,
+                });
+            }
+
+            return devices;
+        }
+
+        private static string Signature(List<AudioDevice> playout)
+        {
+            var builder = new StringBuilder();
+            foreach (var device in playout)
+                builder.Append(device.Guid).Append('\u001f').Append((int)device.Kind).Append('\u001e');
+            return builder.ToString();
+        }
+    }
+}
+#endif

--- a/Runtime/Scripts/Audio/IosRouteController.cs.meta
+++ b/Runtime/Scripts/Audio/IosRouteController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b7a83f0ed8eb4ce1bbd824fdf80c424
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Scripts/Audio/PlatformAudio.cs
+++ b/Runtime/Scripts/Audio/PlatformAudio.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using LiveKit.Proto;
 using LiveKit.Internal;
 using LiveKit.Internal.FFI.Requests;
@@ -35,6 +36,31 @@ namespace LiveKit
 #endif
 
     /// <summary>
+    /// The kind of audio output device, used for ranked routing policies on mobile
+    /// platforms (see <see cref="PlatformAudio.OutputPreference"/>).
+    ///
+    /// The numeric values mirror the planned FFI protocol enum (AudioDeviceKind) one-to-one
+    /// so a future FFI-backed implementation maps without translation. Do not renumber.
+    /// </summary>
+    public enum AudioOutputKind
+    {
+        /// <summary>The platform did not report a device type.</summary>
+        Unknown = 0,
+        /// <summary>The phone's built-in earpiece (receiver).</summary>
+        Earpiece = 1,
+        /// <summary>The built-in loudspeaker.</summary>
+        Speaker = 2,
+        /// <summary>A wired headset or headphones.</summary>
+        WiredHeadset = 3,
+        /// <summary>A Bluetooth audio device.</summary>
+        Bluetooth = 4,
+        /// <summary>A USB audio device.</summary>
+        Usb = 5,
+        /// <summary>A hearing aid.</summary>
+        HearingAid = 6,
+    }
+
+    /// <summary>
     /// Information about an audio device (microphone or speaker).
     /// </summary>
     public struct AudioDevice
@@ -49,6 +75,17 @@ namespace LiveKit
         /// over index for device selection.
         /// </summary>
         public string Guid;
+        /// <summary>
+        /// The kind of output this device represents. <see cref="AudioOutputKind.Unknown"/>
+        /// where the platform does not report a type — currently all devices: no routing
+        /// backend classifies devices yet.
+        /// </summary>
+        public AudioOutputKind Kind;
+        /// <summary>
+        /// Whether this device is the active output route. Only meaningful once a platform
+        /// routing backend reports selection state — currently always false.
+        /// </summary>
+        public bool IsSelected;
     }
 
     /// <summary>
@@ -73,7 +110,18 @@ namespace LiveKit
     {
         internal readonly FfiHandle Handle;
         private readonly PlatformAudioInfo _info;
+        private readonly IRouteController _routeController;
+        private readonly SynchronizationContext _syncContext;
+        private List<AudioOutputKind> _outputPreference = new List<AudioOutputKind>(DefaultOutputPreference);
         private bool _disposed = false;
+
+        private static readonly AudioOutputKind[] DefaultOutputPreference =
+        {
+            AudioOutputKind.Bluetooth,
+            AudioOutputKind.WiredHeadset,
+            AudioOutputKind.Speaker,
+            AudioOutputKind.Earpiece,
+        };
 
         /// <summary>
         /// Number of available recording (microphone) devices.
@@ -118,7 +166,22 @@ namespace LiveKit
             Handle = FfiHandle.FromOwnedHandle(platformAudio.Handle);
             _info = platformAudio.Info;
 
+            _syncContext = SynchronizationContext.Current;
+            _routeController = CreateRouteController();
+            _routeController.DevicesChanged += OnRouteControllerDevicesChanged;
+
             Utils.Debug($"PlatformAudio created: {RecordingDeviceCount} recording devices, {PlayoutDeviceCount} playout devices");
+        }
+
+        private IRouteController CreateRouteController()
+        {
+#if UNITY_ANDROID && !UNITY_EDITOR
+            return new UnsupportedRouteController(this, "Android");
+#elif UNITY_IOS && !UNITY_EDITOR
+            return new UnsupportedRouteController(this, "iOS");
+#else
+            return new DesktopRouteController(this);
+#endif
         }
 
         /// <summary>
@@ -146,6 +209,16 @@ namespace LiveKit
         /// Thrown if device enumeration failed.
         /// </exception>
         public (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevices()
+        {
+            return _routeController.GetDevices();
+        }
+
+        /// <summary>
+        /// Device enumeration through the FFI, shared by the route controllers.
+        /// <see cref="AudioDevice.Kind"/> and <see cref="AudioDevice.IsSelected"/> are not
+        /// reported by the FFI and stay at their defaults (Unknown / false).
+        /// </summary>
+        internal (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevicesViaFfi()
         {
             using var request = FFIBridge.Instance.NewRequest<GetAudioDevicesRequest>();
             request.request.PlatformAudioHandle = (ulong)Handle.DangerousGetHandle();
@@ -177,6 +250,199 @@ namespace LiveKit
             }
 
             return (recording, playout);
+        }
+
+        /// <summary>
+        /// Ranked automatic output routing policy, most preferred first. When no explicit
+        /// output override is active (<see cref="SelectOutput"/>), the platform routes to
+        /// the highest-ranked kind that has a connected device.
+        ///
+        /// Default: Bluetooth > WiredHeadset > Speaker > Earpiece.
+        ///
+        /// Precedence with <see cref="IsSpeakerOutputPreferred"/>: this list is the single
+        /// source of truth; the bool is convenience sugar that only rewrites the relative
+        /// order of <see cref="AudioOutputKind.Speaker"/> and
+        /// <see cref="AudioOutputKind.Earpiece"/> inside this list, and reading the bool
+        /// reads their current relative order. There is no separate speaker-preference state.
+        ///
+        /// Platform notes: on iOS, external devices (Bluetooth, wired) always take priority
+        /// over the built-in outputs, so the Speaker/Earpiece relative order — i.e.
+        /// <see cref="IsSpeakerOutputPreferred"/> — is the only part of the ranking with an
+        /// effect. On Android the full ranking applies. On desktop, output is selected
+        /// per device (<see cref="SelectOutput"/> / <see cref="SetPlayoutDevice(string)"/>)
+        /// and the ranking has no routing effect. The mobile routing backends are not
+        /// implemented yet in this version: on Android and iOS the value is currently
+        /// stored and round-trips, but has no routing effect either.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown if set to null.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown if the list contains <see cref="AudioOutputKind.Unknown"/> or duplicates.
+        /// </exception>
+        public IReadOnlyList<AudioOutputKind> OutputPreference
+        {
+            get => _outputPreference.AsReadOnly();
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                var ranked = new List<AudioOutputKind>(value.Count);
+                foreach (var kind in value)
+                {
+                    if (kind == AudioOutputKind.Unknown)
+                        throw new ArgumentException(
+                            "OutputPreference cannot contain AudioOutputKind.Unknown", nameof(value));
+                    if (ranked.Contains(kind))
+                        throw new ArgumentException(
+                            $"OutputPreference contains {kind} more than once", nameof(value));
+                    ranked.Add(kind);
+                }
+
+                _outputPreference = ranked;
+                _routeController.ApplyOutputPreference(_outputPreference.AsReadOnly());
+            }
+        }
+
+        /// <summary>
+        /// Whether the loudspeaker is preferred over the earpiece for automatic routing.
+        ///
+        /// Precedence with <see cref="OutputPreference"/>: the list is the single source of
+        /// truth; this bool is convenience sugar that only rewrites the relative order of
+        /// <see cref="AudioOutputKind.Speaker"/> and <see cref="AudioOutputKind.Earpiece"/>
+        /// inside <see cref="OutputPreference"/>, and reading it reads their current
+        /// relative order. There is no separate speaker-preference state. Reading returns
+        /// true when Speaker ranks ahead of Earpiece (or Earpiece is absent), false when
+        /// Speaker is absent. Setting reorders the pair in place at the position of
+        /// whichever currently ranks first, inserting a missing kind next to the present
+        /// one (or appending both when neither is listed) so the value round-trips.
+        ///
+        /// Platform notes: on iOS, external devices (Bluetooth, wired) always take priority
+        /// over the built-in outputs, so this bool is the only part of the ranking with an
+        /// effect. On Android the full ranking applies. On desktop, output is selected
+        /// per device (<see cref="SelectOutput"/> / <see cref="SetPlayoutDevice(string)"/>)
+        /// and the ranking has no routing effect. The mobile routing backends are not
+        /// implemented yet in this version: on Android and iOS the value is currently
+        /// stored and round-trips, but has no routing effect either.
+        /// </summary>
+        public bool IsSpeakerOutputPreferred
+        {
+            get
+            {
+                var speaker = _outputPreference.IndexOf(AudioOutputKind.Speaker);
+                var earpiece = _outputPreference.IndexOf(AudioOutputKind.Earpiece);
+                if (speaker < 0) return false;
+                return earpiece < 0 || speaker < earpiece;
+            }
+            set
+            {
+                var first = value ? AudioOutputKind.Speaker : AudioOutputKind.Earpiece;
+                var second = value ? AudioOutputKind.Earpiece : AudioOutputKind.Speaker;
+
+                var reordered = new List<AudioOutputKind>(_outputPreference.Count + 2);
+                var pairInserted = false;
+                foreach (var kind in _outputPreference)
+                {
+                    if (kind == AudioOutputKind.Speaker || kind == AudioOutputKind.Earpiece)
+                    {
+                        if (!pairInserted)
+                        {
+                            reordered.Add(first);
+                            reordered.Add(second);
+                            pairInserted = true;
+                        }
+                        continue;
+                    }
+                    reordered.Add(kind);
+                }
+                if (!pairInserted)
+                {
+                    reordered.Add(first);
+                    reordered.Add(second);
+                }
+
+                _outputPreference = reordered;
+                _routeController.ApplyOutputPreference(_outputPreference.AsReadOnly());
+            }
+        }
+
+        /// <summary>
+        /// Routes audio output to the given device as a sticky override of the automatic
+        /// <see cref="OutputPreference"/> policy: the route stays on the device until
+        /// <see cref="ClearOutputOverride"/> is called. The device is matched against the
+        /// current <see cref="GetDevices"/> playout list by <see cref="AudioDevice.Guid"/>
+        /// when set, otherwise by index and name.
+        ///
+        /// Platform notes: on desktop this selects the device like
+        /// <see cref="SetPlayoutDevice(string)"/>. On Android and iOS the routing backends
+        /// are not implemented yet in this version and this method throws
+        /// <see cref="NotSupportedException"/>.
+        /// </summary>
+        /// <param name="device">A playout device from <see cref="GetDevices"/>.</param>
+        /// <exception cref="ArgumentException">
+        /// Thrown if the device does not match any current playout device.
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// Thrown on Android and iOS, where no routing backend exists yet.
+        /// </exception>
+        public void SelectOutput(AudioDevice device)
+        {
+            var (_, playout) = GetDevices();
+            foreach (var candidate in playout)
+            {
+                var matches = !string.IsNullOrEmpty(device.Guid)
+                    ? candidate.Guid == device.Guid
+                    : candidate.Index == device.Index && candidate.Name == device.Name;
+                if (!matches) continue;
+
+                _routeController.SelectOutput(candidate);
+                return;
+            }
+
+            throw new ArgumentException(
+                $"Device '{device.Name}' (index {device.Index}, guid {device.Guid ?? "none"}) " +
+                "is not a current playout device", nameof(device));
+        }
+
+        /// <summary>
+        /// Clears the sticky override set by <see cref="SelectOutput"/> so the automatic
+        /// <see cref="OutputPreference"/> policy applies again.
+        ///
+        /// Platform notes: on desktop there is no automatic policy to fall back to yet, so
+        /// clearing keeps the currently selected device (no-op). On Android and iOS no
+        /// override can exist yet (<see cref="SelectOutput"/> throws), so this is a no-op
+        /// there as well.
+        /// </summary>
+        public void ClearOutputOverride()
+        {
+            _routeController.ClearOutputOverride();
+        }
+
+        /// <summary>
+        /// Raised when the set of available audio devices changes, with the current playout
+        /// and recording device lists. Raised on the Unity main thread.
+        ///
+        /// No implementation raises this event yet in this version: desktop hot-plug events
+        /// and the mobile routing backends that produce it are not implemented. Subscribing
+        /// and unsubscribing is safe at any time, including after <see cref="Dispose"/>.
+        /// </summary>
+        public event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged;
+
+        private void OnRouteControllerDevicesChanged(
+            IReadOnlyList<AudioDevice> playout, IReadOnlyList<AudioDevice> recording)
+        {
+            if (_disposed) return;
+
+            if (_syncContext != null && _syncContext != SynchronizationContext.Current)
+            {
+                _syncContext.Post(_ =>
+                {
+                    if (!_disposed)
+                        DevicesChanged?.Invoke(playout, recording);
+                }, null);
+                return;
+            }
+
+            DevicesChanged?.Invoke(playout, recording);
         }
 
         /// <summary>
@@ -363,6 +629,8 @@ namespace LiveKit
         public void Dispose()
         {
             if (_disposed) return;
+            _routeController.DevicesChanged -= OnRouteControllerDevicesChanged;
+            _routeController.Dispose();
             Handle.Dispose();
             _disposed = true;
             Utils.Debug("PlatformAudio disposed");

--- a/Runtime/Scripts/Audio/PlatformAudio.cs
+++ b/Runtime/Scripts/Audio/PlatformAudio.cs
@@ -43,6 +43,15 @@ namespace LiveKit
         /// </summary>
         [DllImport("__Internal")]
         internal static extern void LiveKit_SetAudioEnabled([MarshalAs(UnmanagedType.I1)] bool enabled);
+
+        /// <summary>
+        /// Sets the audio session state (0 idle, 1 playout-only, 2 recording) so the
+        /// plugin can apply the matching category/mode/options (see the state table in
+        /// LiveKitAudioSession.mm). Driven by PlatformAudio, which knows whether
+        /// recording is active and whether call audio is wanted.
+        /// </summary>
+        [DllImport("__Internal")]
+        internal static extern void LiveKit_SetSessionState(int state);
     }
 #endif
 
@@ -87,14 +96,16 @@ namespace LiveKit
         /// </summary>
         public string Guid;
         /// <summary>
-        /// The kind of output this device represents. <see cref="AudioOutputKind.Unknown"/>
-        /// where the platform does not report a type — currently all devices: no routing
-        /// backend classifies devices yet.
+        /// The kind of output this device represents. Reported on iOS for playout devices
+        /// (classified from the audio session's current route); <see
+        /// cref="AudioOutputKind.Unknown"/> where the platform does not report a type —
+        /// recording devices, desktop, and Android, which has no routing backend yet.
         /// </summary>
         public AudioOutputKind Kind;
         /// <summary>
-        /// Whether this device is the active output route. Only meaningful once a platform
-        /// routing backend reports selection state — currently always false.
+        /// Whether this device is the active output route. Reported on iOS for playout
+        /// devices; false where no routing backend reports selection state — recording
+        /// devices, desktop, and Android, which has no routing backend yet.
         /// </summary>
         public bool IsSelected;
     }
@@ -129,6 +140,24 @@ namespace LiveKit
         // Tracks live PlatformAudio instances so the iOS audio session is restored
         // only when the last one is disposed (aligned with the native ADM ref-count).
         private static int _instanceCount;
+
+        // Inputs of the iOS session-state machine (see the state table in
+        // LiveKitAudioSession.mm). PlatformAudio is the driver because it is the one
+        // that knows both: whether recording is active (its own StartRecording/
+        // StopRecording calls) and whether call audio is wanted (SetSessionAudioEnabled).
+        private const int IosSessionStateIdle = 0;
+        private const int IosSessionStatePlayoutOnly = 1;
+        private const int IosSessionStateRecording = 2;
+        private bool _iosRecordingActive;
+        private bool _iosSessionAudioEnabled = true;
+
+        private void UpdateIosSessionState()
+        {
+            var state = !_iosSessionAudioEnabled ? IosSessionStateIdle
+                : _iosRecordingActive ? IosSessionStateRecording
+                : IosSessionStatePlayoutOnly;
+            IOSAudioSessionHelper.LiveKit_SetSessionState(state);
+        }
 #endif
 
         private static readonly AudioOutputKind[] DefaultOutputPreference =
@@ -155,9 +184,12 @@ namespace LiveKit
         /// This must be called before creating any PlatformAudioSource or connecting
         /// to a room if you want automatic speaker playout for remote audio.
         ///
-        /// On iOS, this automatically configures the audio session for VoIP mode
-        /// (PlayAndRecord category with VideoChat mode) to enable hardware echo
-        /// cancellation and microphone input.
+        /// On iOS, this automatically configures the audio session for VoIP use and
+        /// takes app ownership of it. The session's mode follows the call state: a
+        /// voice/video-chat mode (enabling hardware echo cancellation) while recording
+        /// is active, and a music-friendly default mode otherwise (see
+        /// <see cref="StartRecording"/> / <see cref="StopRecording"/> /
+        /// <see cref="SetSessionAudioEnabled"/>).
         /// </summary>
         /// <exception cref="InvalidOperationException">
         /// Thrown if the platform ADM could not be initialized (e.g., no audio devices,
@@ -186,6 +218,13 @@ namespace LiveKit
             _routeController = CreateRouteController();
             _routeController.DevicesChanged += OnRouteControllerDevicesChanged;
 
+#if UNITY_IOS && !UNITY_EDITOR
+            // A fresh instance starts in the playout-only state (recording has not
+            // been started); this matches the plugin's post-configure default, so the
+            // call is a no-op unless an earlier instance left another state behind.
+            UpdateIosSessionState();
+#endif
+
             Utils.Debug($"PlatformAudio created: {RecordingDeviceCount} recording devices, {PlayoutDeviceCount} playout devices");
 
 #if UNITY_IOS && !UNITY_EDITOR
@@ -200,7 +239,7 @@ namespace LiveKit
 #if UNITY_ANDROID && !UNITY_EDITOR
             return new UnsupportedRouteController(this, "Android");
 #elif UNITY_IOS && !UNITY_EDITOR
-            return new UnsupportedRouteController(this, "iOS");
+            return new IosRouteController(this, _outputPreference);
 #else
             return new DesktopRouteController(this);
 #endif
@@ -213,19 +252,23 @@ namespace LiveKit
         /// - Desktop (Windows/macOS/Linux): returns the full list of microphones and
         ///   speakers reported by the OS. Devices can be selected with
         ///   <see cref="SetRecordingDevice(string)"/> / <see cref="SetPlayoutDevice(string)"/>.
-        /// - iOS and Android: returns a single placeholder entry at index 0 for each
-        ///   list, representing the system's currently selected default input/output.
-        ///   The OS owns audio routing on these platforms (AVAudioSession on iOS,
-        ///   AudioManager on Android), so individual devices are not enumerated and
-        ///   selecting one is a no-op (see <see cref="SetRecordingDevice(string)"/> /
+        /// - iOS: the playout list is the audio session's current output route (usually
+        ///   one device, with <see cref="AudioDevice.Kind"/> and
+        ///   <see cref="AudioDevice.IsSelected"/> set) — iOS does not enumerate every
+        ///   reachable output device. The recording list is a single placeholder entry
+        ///   for the OS default input.
+        /// - Android: returns a single placeholder entry at index 0 for each list,
+        ///   representing the system's currently selected default input/output. The OS
+        ///   owns audio routing (AudioManager), so individual devices are not enumerated
+        ///   and selecting one is a no-op (see <see cref="SetRecordingDevice(string)"/> /
         ///   <see cref="SetPlayoutDevice(string)"/>).
         /// </summary>
         /// <returns>
         /// A tuple containing:
         /// - Recording: List of available microphones (on iOS/Android, a single
         ///   placeholder for the OS default input)
-        /// - Playout: List of available speakers/headphones (on iOS/Android, a single
-        ///   placeholder for the OS default output)
+        /// - Playout: List of available speakers/headphones (on iOS, the current output
+        ///   route; on Android, a single placeholder for the OS default output)
         /// </returns>
         /// <exception cref="InvalidOperationException">
         /// Thrown if device enumeration failed.
@@ -290,11 +333,12 @@ namespace LiveKit
         /// Platform notes: on iOS, external devices (Bluetooth, wired) always take priority
         /// over the built-in outputs, so the Speaker/Earpiece relative order — i.e.
         /// <see cref="IsSpeakerOutputPreferred"/> — is the only part of the ranking with an
-        /// effect. On Android the full ranking applies. On desktop, output is selected
-        /// per device (<see cref="SelectOutput"/> / <see cref="SetPlayoutDevice(string)"/>)
-        /// and the ranking has no routing effect. The mobile routing backends are not
-        /// implemented yet in this version: on Android and iOS the value is currently
-        /// stored and round-trips, but has no routing effect either.
+        /// effect; it is applied through the audio session mode and takes effect
+        /// immediately, including mid-call. On desktop, output is selected per device
+        /// (<see cref="SelectOutput"/> / <see cref="SetPlayoutDevice(string)"/>) and the
+        /// ranking has no routing effect. The Android routing backend is not implemented
+        /// yet in this version: the value is stored and round-trips, but has no routing
+        /// effect there.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown if set to null.</exception>
         /// <exception cref="ArgumentException">
@@ -340,11 +384,13 @@ namespace LiveKit
         ///
         /// Platform notes: on iOS, external devices (Bluetooth, wired) always take priority
         /// over the built-in outputs, so this bool is the only part of the ranking with an
-        /// effect. On Android the full ranking applies. On desktop, output is selected
-        /// per device (<see cref="SelectOutput"/> / <see cref="SetPlayoutDevice(string)"/>)
-        /// and the ranking has no routing effect. The mobile routing backends are not
-        /// implemented yet in this version: on Android and iOS the value is currently
-        /// stored and round-trips, but has no routing effect either.
+        /// effect. It decides where audio goes when no external device is connected, is
+        /// applied through the audio session mode (never by overriding the output port),
+        /// and takes effect immediately, including mid-call. On desktop, output is
+        /// selected per device (<see cref="SelectOutput"/> /
+        /// <see cref="SetPlayoutDevice(string)"/>) and the ranking has no routing effect.
+        /// The Android routing backend is not implemented yet in this version: the value
+        /// is stored and round-trips, but has no routing effect there.
         /// </summary>
         public bool IsSpeakerOutputPreferred
         {
@@ -395,16 +441,20 @@ namespace LiveKit
         /// when set, otherwise by index and name.
         ///
         /// Platform notes: on desktop this selects the device like
-        /// <see cref="SetPlayoutDevice(string)"/>. On Android and iOS the routing backends
-        /// are not implemented yet in this version and this method throws
-        /// <see cref="NotSupportedException"/>.
+        /// <see cref="SetPlayoutDevice(string)"/>. On iOS the OS owns output route
+        /// selection and this method throws <see cref="NotSupportedException"/> — present
+        /// the system route picker (AVRoutePickerView) instead, or use
+        /// <see cref="OutputPreference"/> / <see cref="IsSpeakerOutputPreferred"/> for the
+        /// built-in outputs. On Android the routing backend is not implemented yet in
+        /// this version and this method also throws.
         /// </summary>
         /// <param name="device">A playout device from <see cref="GetDevices"/>.</param>
         /// <exception cref="ArgumentException">
         /// Thrown if the device does not match any current playout device.
         /// </exception>
         /// <exception cref="NotSupportedException">
-        /// Thrown on Android and iOS, where no routing backend exists yet.
+        /// Thrown on iOS (the OS owns route selection) and on Android (no routing
+        /// backend exists yet).
         /// </exception>
         public void SelectOutput(AudioDevice device)
         {
@@ -430,8 +480,8 @@ namespace LiveKit
         /// <see cref="OutputPreference"/> policy applies again.
         ///
         /// Platform notes: on desktop there is no automatic policy to fall back to yet, so
-        /// clearing keeps the currently selected device (no-op). On Android and iOS no
-        /// override can exist yet (<see cref="SelectOutput"/> throws), so this is a no-op
+        /// clearing keeps the currently selected device (no-op). On iOS and Android no
+        /// override can exist (<see cref="SelectOutput"/> throws), so this is a no-op
         /// there as well.
         /// </summary>
         public void ClearOutputOverride()
@@ -443,8 +493,10 @@ namespace LiveKit
         /// Raised when the set of available audio devices changes, with the current playout
         /// and recording device lists. Raised on the Unity main thread.
         ///
-        /// No implementation raises this event yet in this version: desktop hot-plug events
-        /// and the mobile routing backends that produce it are not implemented. Subscribing
+        /// On iOS this fires when the audio session's output route changes (headset
+        /// plugged/unplugged, Bluetooth connected, speaker/earpiece switches); the playout
+        /// list is the new route. Desktop hot-plug events and the Android backend are not
+        /// implemented yet in this version, so the event is never raised there. Subscribing
         /// and unsubscribing is safe at any time, including after <see cref="Dispose"/>.
         /// </summary>
         public event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged;
@@ -571,6 +623,9 @@ namespace LiveKit
         /// Recording is started automatically when PlatformAudio is created.
         /// Use this to resume recording after calling StopRecording.
         /// This turns on the system's recording privacy indicator (e.g., on macOS/iOS).
+        /// On iOS this also switches the audio session to its recording state
+        /// (voice/video-chat mode per <see cref="IsSpeakerOutputPreferred"/>, enabling
+        /// hardware echo cancellation).
         /// </summary>
         /// <exception cref="InvalidOperationException">
         /// Thrown if the operation failed.
@@ -610,6 +665,11 @@ namespace LiveKit
             if (res.StartRecording.HasError && !string.IsNullOrEmpty(res.StartRecording.Error))
                 throw new InvalidOperationException($"Failed to start recording: {res.StartRecording.Error}");
 
+#if UNITY_IOS && !UNITY_EDITOR
+            _iosRecordingActive = true;
+            UpdateIosSessionState();
+#endif
+
             Utils.Debug("PlatformAudio: started recording");
 
             // Ensures this method is always a valid iterator even when the PLATFORM_ANDROID
@@ -624,6 +684,8 @@ namespace LiveKit
         /// Use this to temporarily stop recording without disposing PlatformAudio.
         /// This turns off the system's recording privacy indicator (e.g., on macOS/iOS).
         /// Call StartRecording to resume recording.
+        /// On iOS this also switches the audio session back to its playout-only state
+        /// (music-friendly default mode).
         /// </summary>
         /// <exception cref="InvalidOperationException">
         /// Thrown if the operation failed.
@@ -639,6 +701,11 @@ namespace LiveKit
             if (res.StopRecording.HasError && !string.IsNullOrEmpty(res.StopRecording.Error))
                 throw new InvalidOperationException($"Failed to stop recording: {res.StopRecording.Error}");
 
+#if UNITY_IOS && !UNITY_EDITOR
+            _iosRecordingActive = false;
+            UpdateIosSessionState();
+#endif
+
             Utils.Debug("PlatformAudio: stopped recording");
         }
 
@@ -649,7 +716,8 @@ namespace LiveKit
         /// of the shared AVAudioSession. It is enabled by default when PlatformAudio is
         /// created, so this only needs to be called to <c>false</c> when leaving a room
         /// (and back to <c>true</c> when rejoining). Disabling stops the microphone/
-        /// remote audio path and the hardware voice processing, but keeps the audio
+        /// remote audio path and the hardware voice processing, and drops the session
+        /// to its idle state (music-friendly default mode), but keeps the audio
         /// session active so other Unity audio (e.g. background music) is not
         /// interrupted — which is why Unity audio survives a hang-up.
         ///
@@ -660,6 +728,8 @@ namespace LiveKit
         {
 #if UNITY_IOS && !UNITY_EDITOR
             IOSAudioSessionHelper.LiveKit_SetAudioEnabled(enabled);
+            _iosSessionAudioEnabled = enabled;
+            UpdateIosSessionState();
 #endif
             Utils.Debug($"PlatformAudio: session audio enabled={enabled}");
         }

--- a/Runtime/Scripts/Audio/RouteController.cs
+++ b/Runtime/Scripts/Audio/RouteController.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+
+namespace LiveKit
+{
+    /// <summary>
+    /// Backend seam for audio output routing. <see cref="PlatformAudio"/> registers one
+    /// implementation per platform and forwards its public routing API
+    /// (<see cref="PlatformAudio.OutputPreference"/>, <see cref="PlatformAudio.SelectOutput"/>,
+    /// <see cref="PlatformAudio.ClearOutputOverride"/>, <see cref="PlatformAudio.GetDevices"/>,
+    /// <see cref="PlatformAudio.DevicesChanged"/>) through it, so the plumbing can be swapped
+    /// per platform — and later wholesale for an FFI-backed implementation — without changing
+    /// a public signature.
+    /// </summary>
+    internal interface IRouteController : IDisposable
+    {
+        /// <summary>Snapshot of the current recording and playout device lists.</summary>
+        (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevices();
+
+        /// <summary>Applies the ranked automatic output policy, most preferred first.</summary>
+        void ApplyOutputPreference(IReadOnlyList<AudioOutputKind> ranked);
+
+        /// <summary>
+        /// Routes output to the given device as a sticky override of the automatic policy.
+        /// The device has already been validated against the current playout snapshot.
+        /// </summary>
+        void SelectOutput(AudioDevice device);
+
+        /// <summary>Clears the sticky override so the automatic policy applies again.</summary>
+        void ClearOutputOverride();
+
+        /// <summary>
+        /// Raised when the available devices change, with the current (playout, recording)
+        /// lists. May be raised from any thread; <see cref="PlatformAudio"/> marshals it to
+        /// the Unity main thread before re-raising publicly.
+        /// </summary>
+        event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged;
+    }
+
+    /// <summary>
+    /// Desktop routing backend: wraps the FFI device enumeration and per-device GUID
+    /// selection. Ranked-kind policy is not implemented on desktop (output is chosen per
+    /// device), and no desktop hot-plug events exist yet, so <see cref="DevicesChanged"/>
+    /// is never raised.
+    /// </summary>
+    internal sealed class DesktopRouteController : IRouteController
+    {
+        private readonly PlatformAudio _owner;
+
+        public DesktopRouteController(PlatformAudio owner)
+        {
+            _owner = owner;
+        }
+
+        public (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevices()
+        {
+            return _owner.GetDevicesViaFfi();
+        }
+
+        public void ApplyOutputPreference(IReadOnlyList<AudioOutputKind> ranked)
+        {
+            // No routing effect on desktop: output is selected per device, not by kind.
+        }
+
+        public void SelectOutput(AudioDevice device)
+        {
+            if (!string.IsNullOrEmpty(device.Guid))
+                _owner.SetPlayoutDevice(device.Guid);
+            else
+                _owner.SetPlayoutDevice(device.Index);
+        }
+
+        public void ClearOutputOverride()
+        {
+            // No automatic policy to fall back to on desktop; the selected device stays.
+        }
+
+        public event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Placeholder backend for platforms whose routing implementation has not landed yet
+    /// (Android, iOS). Device snapshots still work through the FFI (a single placeholder
+    /// entry for the OS default input/output); the routing verbs throw or no-op as
+    /// documented on the public API.
+    /// </summary>
+    internal sealed class UnsupportedRouteController : IRouteController
+    {
+        private readonly PlatformAudio _owner;
+        private readonly string _platform;
+
+        public UnsupportedRouteController(PlatformAudio owner, string platform)
+        {
+            _owner = owner;
+            _platform = platform;
+        }
+
+        public (List<AudioDevice> Recording, List<AudioDevice> Playout) GetDevices()
+        {
+            return _owner.GetDevicesViaFfi();
+        }
+
+        public void ApplyOutputPreference(IReadOnlyList<AudioOutputKind> ranked)
+        {
+            // Stored by PlatformAudio; no routing effect until this platform's backend lands.
+        }
+
+        public void SelectOutput(AudioDevice device)
+        {
+            throw new NotSupportedException(
+                $"SelectOutput is not implemented on {_platform} yet");
+        }
+
+        public void ClearOutputOverride()
+        {
+            // No override can exist on this platform: SelectOutput throws.
+        }
+
+        public event Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> DevicesChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Runtime/Scripts/Audio/RouteController.cs
+++ b/Runtime/Scripts/Audio/RouteController.cs
@@ -88,7 +88,7 @@ namespace LiveKit
 
     /// <summary>
     /// Placeholder backend for platforms whose routing implementation has not landed yet
-    /// (Android, iOS). Device snapshots still work through the FFI (a single placeholder
+    /// (Android). Device snapshots still work through the FFI (a single placeholder
     /// entry for the OS default input/output); the routing verbs throw or no-op as
     /// documented on the public API.
     /// </summary>

--- a/Runtime/Scripts/Audio/RouteController.cs.meta
+++ b/Runtime/Scripts/Audio/RouteController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a99955b361ca4e5aa765a7e6dfc9e73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/PlayMode/PlatformAudioTests.cs
+++ b/Tests/PlayMode/PlatformAudioTests.cs
@@ -103,6 +103,126 @@ namespace LiveKit.PlayModeTests
         }
 
         [UnityTest]
+        public IEnumerator OutputPreference_DefaultsAndRoundtrips()
+        {
+            using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            // Documented default ranking.
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    AudioOutputKind.Bluetooth,
+                    AudioOutputKind.WiredHeadset,
+                    AudioOutputKind.Speaker,
+                    AudioOutputKind.Earpiece,
+                },
+                platformAudio.OutputPreference);
+
+            // Set/get roundtrip preserves order and content.
+            var ranked = new[] { AudioOutputKind.Usb, AudioOutputKind.Speaker, AudioOutputKind.Bluetooth };
+            platformAudio.OutputPreference = ranked;
+            CollectionAssert.AreEqual(ranked, platformAudio.OutputPreference);
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator OutputPreference_RejectsInvalidLists()
+        {
+            using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            Assert.Throws<ArgumentNullException>(() => platformAudio.OutputPreference = null);
+            Assert.Throws<ArgumentException>(() =>
+                platformAudio.OutputPreference = new[] { AudioOutputKind.Unknown });
+            Assert.Throws<ArgumentException>(() =>
+                platformAudio.OutputPreference = new[] { AudioOutputKind.Speaker, AudioOutputKind.Speaker });
+
+            // A rejected assignment leaves the stored preference untouched.
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    AudioOutputKind.Bluetooth,
+                    AudioOutputKind.WiredHeadset,
+                    AudioOutputKind.Speaker,
+                    AudioOutputKind.Earpiece,
+                },
+                platformAudio.OutputPreference);
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator SpeakerPreference_BoolAndListOrderAreOneState()
+        {
+            using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            // Default ranking has Speaker ahead of Earpiece.
+            Assert.IsTrue(platformAudio.IsSpeakerOutputPreferred);
+
+            // Setting the bool rewrites the Speaker/Earpiece order inside the list.
+            platformAudio.IsSpeakerOutputPreferred = false;
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    AudioOutputKind.Bluetooth,
+                    AudioOutputKind.WiredHeadset,
+                    AudioOutputKind.Earpiece,
+                    AudioOutputKind.Speaker,
+                },
+                platformAudio.OutputPreference);
+            Assert.IsFalse(platformAudio.IsSpeakerOutputPreferred);
+
+            // Setting the list order flips the bool back — the list is the source of truth.
+            platformAudio.OutputPreference = new[]
+            {
+                AudioOutputKind.Speaker,
+                AudioOutputKind.Earpiece,
+                AudioOutputKind.Bluetooth,
+            };
+            Assert.IsTrue(platformAudio.IsSpeakerOutputPreferred);
+
+            // A missing kind is inserted next to the present one so the value round-trips.
+            platformAudio.OutputPreference = new[] { AudioOutputKind.Bluetooth, AudioOutputKind.Speaker };
+            platformAudio.IsSpeakerOutputPreferred = false;
+            CollectionAssert.AreEqual(
+                new[] { AudioOutputKind.Bluetooth, AudioOutputKind.Earpiece, AudioOutputKind.Speaker },
+                platformAudio.OutputPreference);
+            Assert.IsFalse(platformAudio.IsSpeakerOutputPreferred);
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator SelectOutput_BogusDevice_Throws()
+        {
+            using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            var bogus = new AudioDevice { Index = 9999, Name = "not-a-device", Guid = "no-such-guid" };
+            Assert.Throws<ArgumentException>(() => platformAudio.SelectOutput(bogus));
+
+            // Clearing is always safe, whether or not an override exists.
+            Assert.DoesNotThrow(() => platformAudio.ClearOutputOverride());
+
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator DevicesChanged_SubscribeUnsubscribe_SafeAcrossDispose()
+        {
+            var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();
+
+            Action<IReadOnlyList<AudioDevice>, IReadOnlyList<AudioDevice>> handler = (playout, recording) => { };
+            platformAudio.DevicesChanged += handler;
+            platformAudio.Dispose();
+
+            Assert.DoesNotThrow(() => platformAudio.DevicesChanged -= handler);
+            Assert.DoesNotThrow(() => platformAudio.DevicesChanged += handler);
+            Assert.DoesNotThrow(() => platformAudio.Dispose());
+
+            yield break;
+        }
+
+        [UnityTest]
         public IEnumerator StartThenStopRecording_DoesNotThrow()
         {
             using var platformAudio = PlatformAudioTestHelper.TryCreateOrIgnore();


### PR DESCRIPTION
### Background

PR #346 made iOS playout stable by putting the app in charge of the audio session, but it left the session in a single static config (PlayAndRecord + VideoChat) for the whole PlatformAudio lifetime — so Unity music plays at call volume even when the user is just listening — and PAR-019's routing API (#370) had no iOS backend: `IsSpeakerOutputPreferred` round-tripped without effect and `DevicesChanged` never fired. This PR is Option A's iOS half: speaker-vs-earpiece preference, session state transitions, and route-change observation, kept behind the C#↔.mm seam so phase B can move the semantics native (PAR-008/PAR-017) and shrink the plugin mechanically.

**Stacked on #369** (which is on #346), and the branch has `max/par-019-routing-api-surface` (#370) merged in for the `IRouteController` seam — the diff shows PAR-019's commit until #370 merges. Merge order: #346 → #369 → #370 → this.

### Changes

- **Session-state machine** in `LiveKitAudioSession.mm`, driven from C# (`PlatformAudio` knows recording state): ctor → playout-only, `StartRecording`/`StopRecording` → recording/playout-only, `SetSessionAudioEnabled(false)` → idle. State table (documented in the .mm header):
  - idle / playout-only: `PlayAndRecord` + mode `Default` + `MixWithOthers` (+ `DefaultToSpeaker` iff speaker preferred) — music-friendly between/before calls
  - recording: `PlayAndRecord` + mode **`VideoChat`** (speaker) / **`VoiceChat`** (earpiece), no `DefaultToSpeaker` — the preference is expressed by the mode alone, never `overrideOutputAudioPort`, so headsets always win
- **Open question from the card, resolved with evidence**: the fork's ADM supports playout-only via an input-disabled VPIO unit (`InitPlayout → InitPlayOrRecord(false) → Initialize(sr, enable_input=false)`), but nothing establishes VPIO under category `Playback` — hence playout-only keeps `PlayAndRecord` with mode `Default` + `MixWithOthers`. Music volume was measured on device, not assumed.
- **Every apply is mirrored into WebRTC's `RTCAudioSessionConfiguration` snapshot** via the reflected `setWebRTCConfiguration:` (still `NSClassFromString` only, no link-time dependency), so ADM-driven reconfigurations re-apply our config instead of the `+initialize`-frozen snapshot. The #369 foreground recovery now re-asserts the current state's config instead of hardcoded VideoChat, and logs expected vs. actual.
- **New `IosRouteController`** implements the PAR-019 seam: playout list = the session's current output route with real `Kind`/`IsSelected` (port-type mapping lives in the .mm), `DevicesChanged` raised from `AVAudioSessionRouteChangeNotification` (marshalled to the Unity main thread by `PlatformAudio`), `OutputPreference` reduces to the Speaker/Earpiece relative order, `SelectOutput` throws the documented `NotSupportedException` pointing at `AVRoutePickerView`.
- **Audio-unit rebuild after mid-call mode changes**: the ADM skips the VPIO rebuild on same-rate route changes (`HandleValidRouteChange → HandleSampleRateChange` no-ops), which left the loudspeaker attenuated by receiver-calibrated echo control after an earpiece → speaker toggle (device-observed). `LiveKit_ApplySessionConfig` now cycles `isAudioEnabled` after a mode change while call audio is wanted — the same rebuild the foreground recovery uses — at the cost of a brief audio gap per toggle.
- iOS 26 SDK: `AllowBluetooth` → `AllowBluetoothHFP` behind the same version guard the WebRTC fork uses; no option is load-bearing for the in-call speaker preference.
- Public XML docs updated truthfully for iOS (device list = current route, event semantics, typed `SelectOutput` throw). No public API surface changes (PAR-019's surface is frozen).

### Testing

- csc on the real iOS-player Bee rsp and the editor rsp, both clean; `clang -fsyntax-only` against the iphoneos SDK under ARC and MRC
- **Device-tested (2026-08-14, full timeline on both Unity 2022.3.62f1 and Unity 6 builds)**: listen-only join keeps music on the loudspeaker in the music-friendly config; unmute switches to VideoChat with working AEC; mid-call speaker↔earpiece toggling applies immediately; `DevicesChanged` fires on BT connect/disconnect and mode switches, on the Unity main thread; interruption (Siri/call) and background/foreground recovery work with who-won logs; music survives hang-up; session restores on dispose. The quiet-loudspeaker-after-toggle issue found in the first Unity 6 round is fixed by the rebuild commit and was re-verified on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)