### PR TITLE
Strip DWARF from local iOS release FFI builds like CI

### DIFF
--- a/Scripts~/build_ffi_locally.sh
+++ b/Scripts~/build_ffi_locally.sh
@@ -122,6 +122,14 @@ if [ $BUILD_STATUS -ne 0 ]; then
     exit 1
 fi
 
+# For iOS release, strip DWARF debug info from the static archive like CI does
+if [ "$PLATFORM" = "ios" ] && [ "$BUILD_TYPE" = "release" ]; then
+    echo ""
+    echo "Stripping DWARF debug info from $(basename "$SRC")..."
+    xcrun strip -S "$SRC"
+    xcrun ranlib "$SRC"
+fi
+
 # Copy the built lib
 echo ""
 echo "Copying to $DST..."


### PR DESCRIPTION
### Background

livekit/rust-sdks#1248 adds a post-build step to the FFI CI: release iOS static archives get their DWARF debug info, shrinking `liblivekit_ffi.a` from ~462 MiB to ~45 MiB. 

I adapted the local build script I use for development to do the same.

### Changes

- Local iOS release builds of the ffi are stripped

Verified by building and testing the stripped release lib on device.
