### PR TITLE
fix: Start Docker daemon on Windows runner before building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,10 @@ jobs:
            Library-${{ env.UNITY_PROJECT_PATH }}-${{ matrix.targetPlatform }}-
            Library-${{ env.UNITY_PROJECT_PATH }}-
            Library-
+     - name: Start Docker
+       run: |
+         Start-Service Docker
+       shell: powershell
      - name: Build
        uses: game-ci/unity-builder@v4
        env:


### PR DESCRIPTION
### Background

The Windows build job was flaky because the Docker daemon was not running. The game-ci/unity-builder action internally uses Docker, which requires the daemon to be active. This fix adds a step to start the Docker service before the build step on the Windows runner.

Fixes the error: "failed to connect to the docker API at npipe:////./pipe/docker_engine"